### PR TITLE
Sm/aura-lwc-pulls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,4 @@
 
 export * from './sourceTracking';
 export * from './compatibility';
-export { RemoteSyncInput } from './shared/types';
+export { RemoteSyncInput, ChangeResult } from './shared/types';

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -15,28 +15,8 @@ import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
 import { Dictionary, Optional } from '@salesforce/ts-types';
 import { env, toNumber } from '@salesforce/kit';
 import { RemoteSyncInput } from '../shared/types';
+import { ChangeResult, RemoteChangeElement, MemberRevision, SourceMember } from './types';
 import { getMetadataKeyFromFileResponse } from './metadataKeys';
-
-export type MemberRevision = {
-  serverRevisionCounter: number;
-  lastRetrievedFromServer: number | null;
-  memberType: string;
-  isNameObsolete: boolean;
-};
-
-export type SourceMember = {
-  MemberType: string;
-  MemberName: string;
-  IsNameObsolete: boolean;
-  RevisionCounter: number;
-};
-
-export type RemoteChangeElement = {
-  name: string;
-  type: string;
-  deleted?: boolean;
-  modified?: boolean;
-};
 
 // represents the contents of the config file stored in 'maxRevision.json'
 interface Contents {
@@ -574,3 +554,25 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
     }
   }
 }
+
+/**
+ * pass in an RCE, and this will return a pullable ChangeResult.
+ * Useful for correcing bundle types where the files show change results with types but aren't resolvable
+ */
+export const remoteChangeElementToChangeResult = (rce: RemoteChangeElement): ChangeResult => {
+  return {
+    ...rce,
+    ...(mappingsForSourceMemberTypesToMetadataType.has(rce.type)
+      ? {
+          name: rce.name.split('/')[0],
+          type: mappingsForSourceMemberTypesToMetadataType.get(rce.type),
+        }
+      : {}),
+    origin: 'remote', // we know they're remote
+  };
+};
+
+const mappingsForSourceMemberTypesToMetadataType = new Map<string, string>([
+  ['AuraDefinition', 'AuraDefinitionBundle'],
+  ['LightningComponentResource', 'LightningComponentBundle'],
+]);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,3 +8,32 @@
 import { FileResponse } from '@salesforce/source-deploy-retrieve';
 
 export type RemoteSyncInput = Pick<FileResponse, 'fullName' | 'filePath' | 'type' | 'state'>;
+
+export type RemoteChangeElement = {
+  name: string;
+  type: string;
+  deleted?: boolean;
+  modified?: boolean;
+};
+
+/**
+ * Summary type that supports both local and remote change types
+ */
+export type ChangeResult = Partial<RemoteChangeElement> & {
+  origin: 'local' | 'remote';
+  filenames?: string[];
+};
+
+export type MemberRevision = {
+  serverRevisionCounter: number;
+  lastRetrievedFromServer: number | null;
+  memberType: string;
+  isNameObsolete: boolean;
+};
+
+export type SourceMember = {
+  MemberType: string;
+  MemberName: string;
+  IsNameObsolete: boolean;
+  RevisionCounter: number;
+};

--- a/test/unit/remoteSourceTracking.test.ts
+++ b/test/unit/remoteSourceTracking.test.ts
@@ -15,12 +15,8 @@ import * as kit from '@salesforce/kit';
 import { expect } from 'chai';
 import { SinonStub } from 'sinon';
 import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
-import {
-  RemoteSourceTrackingService,
-  SourceMember,
-  MemberRevision,
-} from '../../src/shared/remoteSourceTrackingService';
-import { RemoteSyncInput } from '../../src/shared/types';
+import { RemoteSourceTrackingService } from '../../src/shared/remoteSourceTrackingService';
+import { RemoteSyncInput, SourceMember, MemberRevision } from '../../src/shared/types';
 Messages.importMessagesDirectory(__dirname);
 
 const getSourceMember = (revision: number, deleted = false): SourceMember => ({


### PR DESCRIPTION
### What does this PR do?
translates between sourceMember subTypes and real mdTypes when building a list of things that need to pull.

`remoteChangeElementToChangeResult` is now the place to put any special handling logic related to those mappings.

### What issues does this PR fix or reference?
I found this while testing @W-5234323@, and it needed to be fixed for that WI to pass.

But it's not *that* related to the WI description