### PR TITLE
Sm/only-pull-stuff-in-registry

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,4 +1,4 @@
 {
-    "productTag": "a1aB00000004Bx8IAE",
-    "defaultBuild": "offcore.tooling.52"
+  "productTag": "a1aB00000004Bx8IAE",
+  "defaultBuild": "offcore.tooling.53"
 }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "sinon": "^10.0.0",
     "ts-node": "^10.1.0",
     "ts-prune": "^0.10.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.4"
   },
   "oclif": {
     "commands": "./lib/commands",

--- a/src/shared/guards.ts
+++ b/src/shared/guards.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { SourceComponent, ComponentLike } from '@salesforce/source-deploy-retrieve';
 
 export const stringGuard = (input: string | undefined): input is string => {
   return typeof input === 'string';
@@ -12,4 +12,8 @@ export const stringGuard = (input: string | undefined): input is string => {
 
 export const sourceComponentGuard = (input: SourceComponent | undefined): input is SourceComponent => {
   return input instanceof SourceComponent;
+};
+
+export const componentLikeGuard = (input: ComponentLike | undefined): input is ComponentLike => {
+  return input !== undefined && typeof input.fullName === 'string' && typeof input.type === 'string';
 };

--- a/src/shared/guards.ts
+++ b/src/shared/guards.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SourceComponent, ComponentLike } from '@salesforce/source-deploy-retrieve';
+import { SourceComponent, MetadataMember } from '@salesforce/source-deploy-retrieve';
 
 export const stringGuard = (input: string | undefined): input is string => {
   return typeof input === 'string';
@@ -14,6 +14,6 @@ export const sourceComponentGuard = (input: SourceComponent | undefined): input 
   return input instanceof SourceComponent;
 };
 
-export const componentLikeGuard = (input: ComponentLike | undefined): input is ComponentLike => {
+export const metadataMemberGuard = (input: MetadataMember | undefined): input is MetadataMember => {
   return input !== undefined && typeof input.fullName === 'string' && typeof input.type === 'string';
 };

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -572,7 +572,7 @@ export class SourceTracking extends AsyncCreatable {
     }
 
     this.logger.debug('populateFilePaths for change elements', elements);
-    // component set generated from an array of ComponentLike from all the remote changes
+    // component set generated from an array of MetadataMember from all the remote changes
     // but exclude the ones that aren't in the registry
     const remoteChangesAsMetadataMember = elements
       .map((element) => {

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -575,7 +575,6 @@ export class SourceTracking extends AsyncCreatable {
     this.logger.debug('populateFilePaths for change elements', elements);
     // component set generated from an array of ComponentLike from all the remote changes
     // but exclude the ones that aren't in the registry
-    const expectedSkippedElements: ChangeResult[] = [];
     const remoteChangesAsComponentLike = elements
       .map((element) => {
         if (typeof element.type === 'string' && typeof element.name === 'string') {
@@ -584,15 +583,13 @@ export class SourceTracking extends AsyncCreatable {
             fullName: element.name,
           };
         }
-        process.emitWarning(`Not present in registry: ${element.type}`);
-        expectedSkippedElements.push(element);
       })
       .filter(componentLikeGuard) as ComponentLike[];
 
     const remoteChangesAsComponentSet = new ComponentSet(remoteChangesAsComponentLike);
 
     this.logger.debug(` the generated component set has ${remoteChangesAsComponentSet.size.toString()} items`);
-    if (remoteChangesAsComponentSet.size < elements.length - expectedSkippedElements.length) {
+    if (remoteChangesAsComponentSet.size < elements.length) {
       // iterate the elements to see which ones didn't make it into the component set
       throw new Error(
         `unable to generate complete component set for ${elements

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -17,7 +17,6 @@ import {
   SourceComponent,
   FileResponse,
   ForceIgnore,
-  ComponentLike,
   DestructiveChangesType,
   RegistryAccess,
 } from '@salesforce/source-deploy-retrieve';
@@ -34,7 +33,7 @@ import {
   LocalUpdateOptions,
   RemoteChangeElement,
 } from './shared/types';
-import { stringGuard, sourceComponentGuard, componentLikeGuard } from './shared/guards';
+import { stringGuard, sourceComponentGuard, metadataMemberGuard } from './shared/guards';
 import { getKeyFromObject, getMetadataKey } from './shared/functions';
 
 export interface SourceTrackingOptions {
@@ -575,7 +574,7 @@ export class SourceTracking extends AsyncCreatable {
     this.logger.debug('populateFilePaths for change elements', elements);
     // component set generated from an array of ComponentLike from all the remote changes
     // but exclude the ones that aren't in the registry
-    const remoteChangesAsComponentLike = elements
+    const remoteChangesAsMetadataMember = elements
       .map((element) => {
         if (typeof element.type === 'string' && typeof element.name === 'string') {
           return {
@@ -584,9 +583,9 @@ export class SourceTracking extends AsyncCreatable {
           };
         }
       })
-      .filter(componentLikeGuard) as ComponentLike[];
+      .filter(metadataMemberGuard);
 
-    const remoteChangesAsComponentSet = new ComponentSet(remoteChangesAsComponentLike);
+    const remoteChangesAsComponentSet = new ComponentSet(remoteChangesAsMetadataMember);
 
     this.logger.debug(` the generated component set has ${remoteChangesAsComponentSet.size.toString()} items`);
     if (remoteChangesAsComponentSet.size < elements.length) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6023,10 +6023,15 @@ typedoc@0.18.0:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.10.2"
 
-typescript@^4.1.3, typescript@^4.3.5:
+typescript@^4.1.3:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
   integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
+
+typescript@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 uglify-js@^3.1.4:
   version "3.14.1"


### PR DESCRIPTION
### What does this PR do?
when getting remote changes, skip (but warn) if types are not in the registry.  This prevents errors like https://github.com/forcedotcom/source-deploy-retrieve/pull/486 from happening [RCA: metadata API added another type that has the `.rule` suffix

--side change: bump ts

### What issues does this PR fix or reference?
this is the 2nd part of
@W-10101153@

testing notes: the easiest way to play with this is to remove a type (ex: apexclass) from the SDR registry, link that, then link this to plugin-source to run status/pull.  
You should see node warnings but not errors.