### PR TITLE
fix: lightning EmailTemplateFolder

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prune:dead": "ts-prune | grep -v 'source-deploy-retrieve' | grep -v 'index.ts'",
     "test": "sf-test",
     "test:nuts": "nyc mocha \"**/*.nut.ts\" --slow 4500 --timeout 600000 --parallel",
-    "test:nuts:local": "mocha \"**/local*.nut.ts\" --slow 4500 --timeout 600000 --parallel"
+    "test:nuts:local": "mocha \"**/local/*.nut.ts\" --slow 4500 --timeout 600000 --parallel"
   },
   "keywords": [
     "force",

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as path from 'path';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { RemoteSyncInput } from './types';
 import { getMetadataKey } from './functions';
 
@@ -39,7 +40,14 @@ export const getMetadataKeyFromFileResponse = (fileResponse: RemoteSyncInput): s
       getMetadataKey(fileResponse.type, fileResponse.fullName),
     ];
   }
-  // standard key
+  // CustomLabels (file) => CustomLabel[] (how they're storedin SourceMembers)
+  if (fileResponse.type === 'CustomLabels' && fileResponse.filePath) {
+    return ComponentSet.fromSource(fileResponse.filePath)
+      .getSourceComponents()
+      .toArray()
+      .flatMap((component) => component.getChildren().map((child) => getMetadataKey('CustomLabel', child.fullName)));
+  }
+  // standard key for everything else
   return [getMetadataKey(fileResponse.type, fileResponse.fullName)];
 };
 

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as path from 'path';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { RemoteSyncInput } from './types';
 import { getMetadataKey } from './functions';
 
@@ -40,14 +39,7 @@ export const getMetadataKeyFromFileResponse = (fileResponse: RemoteSyncInput): s
       getMetadataKey(fileResponse.type, fileResponse.fullName),
     ];
   }
-  // CustomLabels (file) => CustomLabel[] (how they're storedin SourceMembers)
-  if (fileResponse.type === 'CustomLabels' && fileResponse.filePath) {
-    return ComponentSet.fromSource(fileResponse.filePath)
-      .getSourceComponents()
-      .toArray()
-      .flatMap((component) => component.getChildren().map((child) => getMetadataKey('CustomLabel', child.fullName)));
-  }
-  // standard key for everything else
+  // standard key
   return [getMetadataKey(fileResponse.type, fileResponse.fullName)];
 };
 

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -42,3 +42,9 @@ export const getMetadataKeyFromFileResponse = (fileResponse: RemoteSyncInput): s
   // standard key
   return [getMetadataKey(fileResponse.type, fileResponse.fullName)];
 };
+
+export const mappingsForSourceMemberTypesToMetadataType = new Map<string, string>([
+  ['AuraDefinition', 'AuraDefinitionBundle'],
+  ['LightningComponentResource', 'LightningComponentBundle'],
+  ['EmailTemplateFolder', 'EmailFolder'],
+]);

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -14,7 +14,7 @@ import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
 import { Dictionary, Optional } from '@salesforce/ts-types';
 import { env, toNumber } from '@salesforce/kit';
 import { ChangeResult, RemoteChangeElement, MemberRevision, SourceMember, RemoteSyncInput } from './types';
-import { getMetadataKeyFromFileResponse } from './metadataKeys';
+import { getMetadataKeyFromFileResponse, mappingsForSourceMemberTypesToMetadataType } from './metadataKeys';
 import { getMetadataKey } from './functions';
 
 // represents the contents of the config file stored in 'maxRevision.json'
@@ -566,8 +566,3 @@ export const remoteChangeElementToChangeResult = (rce: RemoteChangeElement): Cha
     origin: 'remote', // we know they're remote
   };
 };
-
-const mappingsForSourceMemberTypesToMetadataType = new Map<string, string>([
-  ['AuraDefinition', 'AuraDefinitionBundle'],
-  ['LightningComponentResource', 'LightningComponentBundle'],
-]);

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -35,6 +35,7 @@ import {
 } from './shared/types';
 import { sourceComponentGuard, metadataMemberGuard } from './shared/guards';
 import { getKeyFromObject, getMetadataKey, isBundle, pathIsInFolder } from './shared/functions';
+import { mappingsForSourceMemberTypesToMetadataType } from './shared/metadataKeys';
 
 export interface SourceTrackingOptions {
   org: Org;
@@ -640,6 +641,9 @@ export class SourceTracking extends AsyncCreatable {
 
   private registrySupportsType(type: string): boolean {
     try {
+      if (mappingsForSourceMemberTypesToMetadataType.has(type)) {
+        return true;
+      }
       // this must use getTypeByName because findType doesn't support addressable child types (ex: customField!)
       this.registry.getTypeByName(type);
       return true;

--- a/test/nuts/local/customLabelsMetadataKeyTranslation.nut.ts
+++ b/test/nuts/local/customLabelsMetadataKeyTranslation.nut.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as path from 'path';
+import { TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
+import { getMetadataKeyFromFileResponse } from '../../../src/shared/metadataKeys';
+
+// this is a NUT to avoid fs-mocking the CustomLabels file that SDR is going to read to getChildren
+describe('end-to-end-test for custom labels', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        sourceDir: path.join('test', 'nuts', 'repros', 'duplabels'),
+      },
+      authStrategy: 'NONE',
+    });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+
+  it('translates labels to label[]', () => {
+    const testResponse = {
+      filePath: path.join(session.project.dir, 'pkg1', 'Test1.labels-meta.xml'),
+      type: 'CustomLabels',
+      state: ComponentStatus.Created,
+      fullName: 'Test1',
+    };
+    expect(getMetadataKeyFromFileResponse(testResponse)).to.deep.equal(['CustomLabel__Label1']);
+  });
+});

--- a/test/nuts/local/localTrackingScenario.nut.ts
+++ b/test/nuts/local/localTrackingScenario.nut.ts
@@ -10,7 +10,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { fs } from '@salesforce/core';
 import { expect } from 'chai';
 import { shouldThrow } from '@salesforce/core/lib/testSetup';
-import { ShadowRepo } from '../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/localShadowRepo';
 
 describe('end-to-end-test for local tracking', () => {
   let session: TestSession;


### PR DESCRIPTION
### What does this PR do?
in source members, lightning email template folder are a different type
in the metadata API and package.xml they all look the same (filenames, extensions) with different content

Since SDR really, really doesn't want to have multiple folder types for EmailTemplate, this PR lets STL map EmailTemplateFolder to EmailFolder and not worry about the differences.

### What issues does this PR fix or reference?
@W-10385112@
https://github.com/forcedotcom/cli/issues/1345