### PR TITLE
fix: lightning EmailTemplateFolder

### DIFF
--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -39,6 +39,13 @@ export const getMetadataKeyFromFileResponse = (fileResponse: RemoteSyncInput): s
       getMetadataKey(fileResponse.type, fileResponse.fullName),
     ];
   }
+  // these might have been emailFolder or emailTemplateFolder on the server, and we can't tell from the file path/name/type, so we'll set BOTH in source tracking
+  if (fileResponse.type === 'EmailFolder' && fileResponse.filePath) {
+    return [
+      getMetadataKey('EmailFolder', fileResponse.fullName),
+      getMetadataKey('EmailTemplateFolder', fileResponse.fullName),
+    ];
+  }
   // standard key
   return [getMetadataKey(fileResponse.type, fileResponse.fullName)];
 };

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -42,3 +42,9 @@ export const getMetadataKeyFromFileResponse = (fileResponse: RemoteSyncInput): s
   // standard key
   return [getMetadataKey(fileResponse.type, fileResponse.fullName)];
 };
+
+export const mappingsForSourceMemberTypesToMetadataType = new Map<string, string>([
+  ['AuraDefinition', 'AuraDefinitionBundle'],
+  ['LightningComponentResource', 'LightningComponentBundle'],
+  ['EmailTemplateFolder', 'EmailFolder'],
+]);

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -14,7 +14,7 @@ import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
 import { Dictionary, Optional } from '@salesforce/ts-types';
 import { env, toNumber } from '@salesforce/kit';
 import { ChangeResult, RemoteChangeElement, MemberRevision, SourceMember, RemoteSyncInput } from './types';
-import { getMetadataKeyFromFileResponse } from './metadataKeys';
+import { getMetadataKeyFromFileResponse, mappingsForSourceMemberTypesToMetadataType } from './metadataKeys';
 import { getMetadataKey } from './functions';
 
 // represents the contents of the config file stored in 'maxRevision.json'
@@ -566,8 +566,3 @@ export const remoteChangeElementToChangeResult = (rce: RemoteChangeElement): Cha
     origin: 'remote', // we know they're remote
   };
 };
-
-const mappingsForSourceMemberTypesToMetadataType = new Map<string, string>([
-  ['AuraDefinition', 'AuraDefinitionBundle'],
-  ['LightningComponentResource', 'LightningComponentBundle'],
-]);

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -35,6 +35,7 @@ import {
 } from './shared/types';
 import { sourceComponentGuard, metadataMemberGuard } from './shared/guards';
 import { getKeyFromObject, getMetadataKey, isBundle, pathIsInFolder } from './shared/functions';
+import { mappingsForSourceMemberTypesToMetadataType } from './shared/metadataKeys';
 
 export interface SourceTrackingOptions {
   org: Org;
@@ -640,6 +641,9 @@ export class SourceTracking extends AsyncCreatable {
 
   private registrySupportsType(type: string): boolean {
     try {
+      if (mappingsForSourceMemberTypesToMetadataType.has(type)) {
+        return true;
+      }
       // this must use getTypeByName because findType doesn't support addressable child types (ex: customField!)
       this.registry.getTypeByName(type);
       return true;


### PR DESCRIPTION
What does this PR do?
in source members, lightning email template folder are a different type
in the metadata API and package.xml they all look the same (filenames, extensions) with different content

Since SDR really, really doesn't want to have multiple folder types for EmailTemplate, this PR lets STL map EmailTemplateFolder to EmailFolder and not worry about the differences.

What issues does this PR fix or reference?
@W-10385112@
forcedotcom/cli#1345