### PR TITLE
Sm/label tracking bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/source-tracking",
   "description": "API for tracking local and remote Salesforce metadata changes",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prune:dead": "ts-prune | grep -v 'source-deploy-retrieve' | grep -v 'index.ts'",
     "test": "sf-test",
     "test:nuts": "nyc mocha \"**/*.nut.ts\" --slow 4500 --timeout 600000 --parallel",
-    "test:nuts:local": "mocha \"**/local*.nut.ts\" --slow 4500 --timeout 600000 --parallel"
+    "test:nuts:local": "mocha \"**/local/*.nut.ts\" --slow 4500 --timeout 600000 --parallel"
   },
   "keywords": [
     "force",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@salesforce/core": "^2.33.1",
     "@salesforce/kit": "^1.5.17",
-    "@salesforce/source-deploy-retrieve": "^5.8.2",
+    "@salesforce/source-deploy-retrieve": "^5.9.3",
     "isomorphic-git": "^1.9.2",
     "ts-retry-promise": "^0.6.0"
   },

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as path from 'path';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { RemoteSyncInput } from './types';
 import { getMetadataKey } from './functions';
 
@@ -39,7 +40,14 @@ export const getMetadataKeyFromFileResponse = (fileResponse: RemoteSyncInput): s
       getMetadataKey(fileResponse.type, fileResponse.fullName),
     ];
   }
-  // standard key
+  // CustomLabels (file) => CustomLabel[] (how they're storedin SourceMembers)
+  if (fileResponse.type === 'CustomLabels' && fileResponse.filePath) {
+    return ComponentSet.fromSource(fileResponse.filePath)
+      .getSourceComponents()
+      .toArray()
+      .flatMap((component) => component.getChildren().map((child) => getMetadataKey('CustomLabel', child.fullName)));
+  }
+  // standard key for everything else
   return [getMetadataKey(fileResponse.type, fileResponse.fullName)];
 };
 

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -54,5 +54,4 @@ export const getMetadataKeyFromFileResponse = (fileResponse: RemoteSyncInput): s
 export const mappingsForSourceMemberTypesToMetadataType = new Map<string, string>([
   ['AuraDefinition', 'AuraDefinitionBundle'],
   ['LightningComponentResource', 'LightningComponentBundle'],
-  ['EmailTemplateFolder', 'EmailFolder'],
 ]);

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -42,3 +42,9 @@ export const getMetadataKeyFromFileResponse = (fileResponse: RemoteSyncInput): s
   // standard key
   return [getMetadataKey(fileResponse.type, fileResponse.fullName)];
 };
+
+export const mappingsForSourceMemberTypesToMetadataType = new Map<string, string>([
+  ['AuraDefinition', 'AuraDefinitionBundle'],
+  ['LightningComponentResource', 'LightningComponentBundle'],
+  ['EmailTemplateFolder', 'EmailFolder'],
+]);

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -14,7 +14,7 @@ import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
 import { Dictionary, Optional } from '@salesforce/ts-types';
 import { env, toNumber } from '@salesforce/kit';
 import { ChangeResult, RemoteChangeElement, MemberRevision, SourceMember, RemoteSyncInput } from './types';
-import { getMetadataKeyFromFileResponse } from './metadataKeys';
+import { getMetadataKeyFromFileResponse, mappingsForSourceMemberTypesToMetadataType } from './metadataKeys';
 import { getMetadataKey } from './functions';
 
 // represents the contents of the config file stored in 'maxRevision.json'
@@ -566,8 +566,3 @@ export const remoteChangeElementToChangeResult = (rce: RemoteChangeElement): Cha
     origin: 'remote', // we know they're remote
   };
 };
-
-const mappingsForSourceMemberTypesToMetadataType = new Map<string, string>([
-  ['AuraDefinition', 'AuraDefinitionBundle'],
-  ['LightningComponentResource', 'LightningComponentBundle'],
-]);

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -678,16 +678,21 @@ export class SourceTracking extends AsyncCreatable {
 
     this.logger.debug(` the generated component set has ${remoteChangesAsComponentSet.size.toString()} items`);
     if (remoteChangesAsComponentSet.size < elements.length) {
+      // there *could* be something missing
+      // some types (ex: LWC) show up as multiple files in the remote changes, but only one in the component set
       // iterate the elements to see which ones didn't make it into the component set
-      throw new Error(
-        `unable to generate complete component set for ${elements
-          .filter(
-            (element) =>
-              !remoteChangesAsComponentSet.has({ type: element?.type as string, fullName: element?.name as string })
-          )
-          .map((element) => `${element.name} (${element.type})`)
-          .join(EOL)}`
+      const missingComponents = elements.filter(
+        (element) =>
+          !remoteChangesAsComponentSet.has({ type: element?.type as string, fullName: element?.name as string })
       );
+      // Throw if anything was actually missing
+      if (missingComponents.length > 0) {
+        throw new Error(
+          `unable to generate complete component set for ${elements
+            .map((element) => `${element.name} (${element.type})`)
+            .join(EOL)}`
+        );
+      }
     }
 
     const matchingLocalSourceComponentsSet = ComponentSet.fromSource({

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -35,6 +35,7 @@ import {
 } from './shared/types';
 import { sourceComponentGuard, metadataMemberGuard } from './shared/guards';
 import { getKeyFromObject, getMetadataKey, isBundle, pathIsInFolder } from './shared/functions';
+import { mappingsForSourceMemberTypesToMetadataType } from './shared/metadataKeys';
 
 export interface SourceTrackingOptions {
   org: Org;
@@ -640,6 +641,9 @@ export class SourceTracking extends AsyncCreatable {
 
   private registrySupportsType(type: string): boolean {
     try {
+      if (mappingsForSourceMemberTypesToMetadataType.has(type)) {
+        return true;
+      }
       // this must use getTypeByName because findType doesn't support addressable child types (ex: customField!)
       this.registry.getTypeByName(type);
       return true;

--- a/test/nuts/local/customLabelsMetadataKeyTranslation.nut.ts
+++ b/test/nuts/local/customLabelsMetadataKeyTranslation.nut.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as path from 'path';
+import { TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
+import { getMetadataKeyFromFileResponse } from '../../../src/shared/metadataKeys';
+
+// this is a NUT to avoid fs-mocking the CustomLabels file that SDR is going to read to getChildren
+describe('end-to-end-test for custom labels', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        sourceDir: path.join('test', 'nuts', 'repros', 'duplabels'),
+      },
+      authStrategy: 'NONE',
+    });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+
+  it('translates labels to label[]', () => {
+    const testResponse = {
+      filePath: path.join(session.project.dir, 'pkg1', 'Test1.labels-meta.xml'),
+      type: 'CustomLabels',
+      state: ComponentStatus.Created,
+      fullName: 'Test1',
+    };
+    expect(getMetadataKeyFromFileResponse(testResponse)).to.deep.equal(['CustomLabel__Label1']);
+  });
+});

--- a/test/nuts/local/localTrackingScenario.nut.ts
+++ b/test/nuts/local/localTrackingScenario.nut.ts
@@ -10,7 +10,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { fs } from '@salesforce/core';
 import { expect } from 'chai';
 import { shouldThrow } from '@salesforce/core/lib/testSetup';
-import { ShadowRepo } from '../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/localShadowRepo';
 
 describe('end-to-end-test for local tracking', () => {
   let session: TestSession;

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,29 +604,7 @@
     shelljs "^0.8.4"
     strip-ansi "6.0.1"
 
-"@salesforce/core@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.31.0.tgz#cdeaa9968060afb52f40c12bf5a4f9844a2a1909"
-  integrity sha512-ROEjX/M0ZHpGlmRfNUoDKsE4ppOZUU5Hcl3XHr2pCO7F505imAmhKg8I+XfGSxXyj4bL/kftkNTK5xFffJ+6mw==
-  dependencies:
-    "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.5.0"
-    "@salesforce/schemas" "^1.0.1"
-    "@salesforce/ts-types" "^1.5.13"
-    "@types/graceful-fs" "^4.1.5"
-    "@types/jsforce" "^1.9.35"
-    "@types/mkdirp" "^1.0.1"
-    debug "^3.1.0"
-    graceful-fs "^4.2.4"
-    jsen "0.6.6"
-    jsforce "^1.11.0"
-    jsonwebtoken "8.5.0"
-    mkdirp "1.0.4"
-    semver "^7.3.5"
-    sfdx-faye "^1.0.9"
-    ts-retry-promise "^0.6.0"
-
-"@salesforce/core@^2.24.0", "@salesforce/core@^2.33.1":
+"@salesforce/core@2.33.1", "@salesforce/core@^2.24.0", "@salesforce/core@^2.33.1":
   version "2.33.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.33.1.tgz#23c22953174ad0e809b2f1c7b2881b5ba8a89d9c"
   integrity sha512-jKVFYEvlV+loBoau5heBOVXmzsPO+RbYh6SPybJK6xF7khQmzu7+WAQbikY2eY8VaXcded2kka8L/FKuD/LKBg==
@@ -712,19 +690,19 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.1.0.tgz#bbf94a11ee036f2b0ec6ba82306cd9565a6ba26b"
   integrity sha512-6D7DvE6nFxpLyyTnrOIbbAeCJw2r/EpinFAcMh6gU0gA/CGfSbwV/8uR3uHLYL2zCyCZLH8jJ4dZ3BzCMqc+Eg==
 
-"@salesforce/source-deploy-retrieve@^5.8.2":
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-5.8.2.tgz#603ef8078db82644287fcfc9ab73c92529d5d2cc"
-  integrity sha512-nzbgKkoz48KC4tBjbA5KsMiBmgu4qrNpmicvZdT6POOQ3F+G/eH84ICqucZ1CqD1bUhYVVbcL8EqZkNtf2jkzg==
+"@salesforce/source-deploy-retrieve@^5.9.3":
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-5.9.3.tgz#e1da99a0f85b01e31821c681b4196296125892bb"
+  integrity sha512-kqMI72Wk63Od4HgEiIkkmVBPWizdRdZGu/5ZzWkxphuSZmOgmaFKlIbsR03IR4D5n38bAs7vrSMNZvKp7HwhyQ==
   dependencies:
-    "@salesforce/core" "2.31.0"
+    "@salesforce/core" "2.33.1"
     "@salesforce/kit" "^1.5.0"
     "@salesforce/ts-types" "^1.4.2"
     archiver "^5.3.0"
     fast-xml-parser "^3.17.4"
     graceful-fs "^4.2.8"
     ignore "^5.1.8"
-    mime "2.4.6"
+    mime "2.6.0"
     unzipper "0.10.11"
     xmldom-sfdx-encoding "^0.1.29"
 
@@ -1234,7 +1212,7 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@*, asap@~2.0.3, asap@~2.0.6:
+asap@*, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -1866,7 +1844,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-csprng@*, csprng@~0.1.2:
+csprng@*:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/csprng/-/csprng-0.1.2.tgz#4bc68f12fa368d252a59841cbaca974b18ab45e2"
   integrity sha1-S8aPEvo2jSUqWYQcusqXSxirReI=
@@ -2584,13 +2562,6 @@ faye-websocket@>=0.9.1:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da"
   integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
-  dependencies:
-    websocket-driver ">=0.5.1"
-
-faye-websocket@~0.9.1:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.9.4.tgz#885934c79effb0409549e0c0a3801ed17a40cdad"
-  integrity sha1-iFk0x57/sECVSeDAo4Ae0XpAza0=
   dependencies:
     websocket-driver ">=0.5.1"
 
@@ -4011,10 +3982,10 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.50.0"
 
-mime@2.4.6:
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
-  integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -4644,7 +4615,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-psl@^1.1.24, psl@^1.1.28, psl@^1.1.33:
+psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
@@ -4656,11 +4627,6 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
-
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
@@ -5002,17 +4968,6 @@ setimmediate@~1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
-
-sfdx-faye@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sfdx-faye/-/sfdx-faye-1.0.9.tgz#24e678ddb783d7085f3e40a2c155ac367416be26"
-  integrity sha512-/p0Ifvhh9rVYj6YmYOBU+psQsP+9RrNrUU4lr1p+HhZhTgnviMIabcgKZUN12S69zUpl0YagpFdMhmxKGkf+5g==
-  dependencies:
-    asap "~2.0.6"
-    csprng "~0.1.2"
-    faye-websocket "~0.9.1"
-    tough-cookie "~2.4.3"
-    tunnel-agent "~0.6.0"
 
 sha.js@^2.4.9:
   version "2.4.11"
@@ -5501,14 +5456,6 @@ tough-cookie@*:
     punycode "^2.1.1"
     universalify "^0.1.2"
 
-tough-cookie@~2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
-  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
-  dependencies:
-    psl "^1.1.24"
-    punycode "^1.4.1"
-
 tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -5614,7 +5561,7 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
-tunnel-agent@*, tunnel-agent@^0.6.0, tunnel-agent@~0.6.0:
+tunnel-agent@*, tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=


### PR DESCRIPTION
### What does this PR do?
remote source tracking files for customLabels weren't updating correctly (beta:pull)

put all the "local" (no-org) NUTs into a folder to it's easy to run them all at once.
bump to v1 so we can start using semver normally

depends on https://github.com/forcedotcom/source-deploy-retrieve/pull/551

### What issues does this PR fix or reference?
@W-10322335@