### PR TITLE
fix: emailTempalteFolder via aliased types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,8 @@ jobs:
           name: Build the external project
           command: |
             yarn clean
+            yarn upgrade @salesforce/source-deploy-retrieve@latest
+            yarn upgrade @salesforce/core@latest
             yarn compile
       - run:
           name: Nuts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,10 @@ jobs:
       - run: git clone <<parameters.external_project_git_url>> $(pwd)
       - run:
           name: Install dependencies
-          command: yarn
+          command: |
+            yarn
+            yarn upgrade @salesforce/source-deploy-retrieve@latest
+            yarn upgrade @salesforce/core@latest
       - when:
           condition:
             equal: ['linux', <<parameters.os>>]
@@ -99,8 +102,6 @@ jobs:
           name: Build the external project
           command: |
             yarn clean
-            yarn upgrade @salesforce/source-deploy-retrieve@latest
-            yarn upgrade @salesforce/core@latest
             yarn compile
       - run:
           name: Nuts

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@salesforce/core": "^2.33.1",
     "@salesforce/kit": "^1.5.17",
-    "@salesforce/source-deploy-retrieve": "^5.9.3",
+    "@salesforce/source-deploy-retrieve": "^5.9.4",
     "isomorphic-git": "^1.9.2",
     "ts-retry-promise": "^0.6.0"
   },

--- a/test/nuts/repros/nested-classes2/README.md
+++ b/test/nuts/repros/nested-classes2/README.md
@@ -1,0 +1,13 @@
+# Test for .gitignore file causing metadata to be ignore when using force:source:push:beta
+
+To run:
+
+    sfdx force:source:beta:push -f
+
+Actual Output:
+
+    No results found
+
+Expected Output:
+
+Ignored.cls should be deployed, if you remove classes/.gitignore it will be. Tested on sfdx-cli/7.131.0 darwin-x64 node-v12.22.7.

--- a/test/nuts/repros/nested-classes2/classes/.gitignore
+++ b/test/nuts/repros/nested-classes2/classes/.gitignore
@@ -1,0 +1,1 @@
+ignored

--- a/test/nuts/repros/nested-classes2/classes/ignored/Ignored.cls
+++ b/test/nuts/repros/nested-classes2/classes/ignored/Ignored.cls
@@ -1,0 +1,1 @@
+public class Ignored {}

--- a/test/nuts/repros/nested-classes2/classes/ignored/Ignored.cls-meta.xml
+++ b/test/nuts/repros/nested-classes2/classes/ignored/Ignored.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/test/nuts/repros/nested-classes2/sfdx-project.json
+++ b/test/nuts/repros/nested-classes2/sfdx-project.json
@@ -1,0 +1,6 @@
+{
+  "packageDirectories": [{ "path": "classes/ignored", "default": true }],
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "53.0"
+}

--- a/test/unit/metadataKeys.test.ts
+++ b/test/unit/metadataKeys.test.ts
@@ -78,4 +78,19 @@ describe('metadataKeys', () => {
       ]);
     });
   });
+
+  describe('alias types', () => {
+    it('creates a key for the type and one for its alias', () => {
+      const fileResponse = {
+        fullName: 'ETF_WTF',
+        type: 'EmailFolder',
+        state: ComponentStatus.Created,
+        filePath: 'force-app/main/default/email/ETF_WTF.emailFolder-meta.xml',
+      };
+      expect(getMetadataKeyFromFileResponse(fileResponse)).to.deep.equal([
+        'EmailFolder__ETF_WTF',
+        'EmailTemplateFolder__ETF_WTF',
+      ]);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,10 +690,10 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.1.0.tgz#bbf94a11ee036f2b0ec6ba82306cd9565a6ba26b"
   integrity sha512-6D7DvE6nFxpLyyTnrOIbbAeCJw2r/EpinFAcMh6gU0gA/CGfSbwV/8uR3uHLYL2zCyCZLH8jJ4dZ3BzCMqc+Eg==
 
-"@salesforce/source-deploy-retrieve@^5.9.3":
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-5.9.3.tgz#e1da99a0f85b01e31821c681b4196296125892bb"
-  integrity sha512-kqMI72Wk63Od4HgEiIkkmVBPWizdRdZGu/5ZzWkxphuSZmOgmaFKlIbsR03IR4D5n38bAs7vrSMNZvKp7HwhyQ==
+"@salesforce/source-deploy-retrieve@^5.9.4":
+  version "5.9.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-5.9.4.tgz#37dfd035baaa510a068854d8f738580c1673273c"
+  integrity sha512-YuRiusKMbs34onmCd4eV219wLEhNdEbpkjkdZ1CXSEDRAZAROydPK8Xh5r3RjJiJaVX+b+HIKANN2XH4HqwhjA==
   dependencies:
     "@salesforce/core" "2.33.1"
     "@salesforce/kit" "^1.5.0"


### PR DESCRIPTION
### What does this PR do?
maps EmailTemplateFolder => EmailFolder using the new registry aliasFor

requires https://github.com/forcedotcom/source-deploy-retrieve/pull/556

### What issues does this PR fix or reference?
@W-10385112@
forcedotcom/cli#1345