### PR TITLE
fix: increase max-fetch default

### DIFF
--- a/messages/compatibility.json
+++ b/messages/compatibility.json
@@ -1,5 +1,5 @@
 {
   "sourceTrackingFileVersionMismatch": "This project uses the %s version of source tracking files.",
   "clearSuggestion": "Clear the %s version of the tracking files by running '%s'",
-  "useOtherVersion": "Use the %s version of the command, '%s' to preserve the tracking files)"
+  "useOtherVersion": "Use the %s version of the command, '%s' to preserve the tracking files"
 }

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -14,11 +14,9 @@ import { getMetadataKey } from './functions';
 const pathAfterFullName = (fileResponse: RemoteSyncInput): string =>
   fileResponse && fileResponse.filePath
     ? join(
-        dirname(fileResponse.filePath)
-          .substring(dirname(fileResponse.filePath).lastIndexOf(fileResponse.fullName))
-          .replace(/\\/gi, '/'),
+        dirname(fileResponse.filePath).substring(dirname(fileResponse.filePath).lastIndexOf(fileResponse.fullName)),
         basename(fileResponse.filePath)
-      )
+      ).replace(/\\/gi, '/')
     : '';
 
 const registry = new RegistryAccess();

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -12,7 +12,7 @@ import { getMetadataKey } from './functions';
 // LWC can have child folders (ex: dynamic templates like /templates/noDataIllustration.html
 const pathAfterFullName = (fileResponse: RemoteSyncInput): string =>
   fileResponse && fileResponse.filePath
-    ? fileResponse.filePath.substr(fileResponse.filePath.indexOf(fileResponse.fullName)).replace(/\\/gi, '/')
+    ? fileResponse.filePath.substr(fileResponse.filePath.lastIndexOf(fileResponse.fullName)).replace(/\\/gi, '/')
     : '';
 
 const registry = new RegistryAccess();
@@ -30,7 +30,7 @@ export const getMetadataKeyFromFileResponse = (fileResponse: RemoteSyncInput): s
   // also create an element for the parent object
   if (fileResponse.type === 'CustomField' && fileResponse.filePath) {
     const splits = path.normalize(fileResponse.filePath).split(path.sep);
-    const objectFolderIndex = splits.indexOf('objects');
+    const objectFolderIndex = splits.lastIndexOf('objects');
     return [
       getMetadataKey('CustomObject', splits[objectFolderIndex + 1]),
       getMetadataKey(fileResponse.type, fileResponse.fullName),

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -28,7 +28,8 @@ interface Contents {
  * even when there is a longer timeout remaining (because the deployment is very large)
  */
 const POLLING_DELAY_MS = 1000;
-const CONSECUTIVE_EMPTY_POLLING_RESULT_LIMIT = env.getNumber('SFDX_SOURCE_MEMBER_POLLING_TIMEOUT') ?? 120;
+const CONSECUTIVE_EMPTY_POLLING_RESULT_LIMIT =
+  (env.getNumber('SFDX_SOURCE_MEMBER_POLLING_TIMEOUT') ?? 120) / Duration.milliseconds(POLLING_DELAY_MS).seconds;
 export namespace RemoteSourceTrackingService {
   // Constructor Options for RemoteSourceTrackingService.
   export interface Options extends ConfigFile.Options {

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -8,11 +8,11 @@
 /* eslint-disable @typescript-eslint/member-ordering */
 
 import * as path from 'path';
-import { retryDecorator } from 'ts-retry-promise';
-import { ConfigFile, Logger, Org, SfdxError, Messages, fs } from '@salesforce/core';
+import { retryDecorator, NotRetryableError } from 'ts-retry-promise';
+import { ConfigFile, Logger, Org, SfdxError, Messages, fs, Lifecycle } from '@salesforce/core';
 import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
 import { Dictionary, Optional } from '@salesforce/ts-types';
-import { env, toNumber } from '@salesforce/kit';
+import { env, toNumber, Duration } from '@salesforce/kit';
 import { ChangeResult, RemoteChangeElement, MemberRevision, SourceMember, RemoteSyncInput } from './types';
 import { getMetadataKeyFromFileResponse, mappingsForSourceMemberTypesToMetadataType } from './metadataKeys';
 import { getMetadataKey } from './functions';
@@ -23,6 +23,11 @@ interface Contents {
   sourceMembers: Dictionary<MemberRevision>;
 }
 
+/*
+ * after some results have returned, how many times should we poll for missing sourcemembers
+ * even when there is a longer timeout remaining (because the deployment is very large)
+ */
+const CONSECUTIVE_EMPTY_POLLING_RESULT_LIMIT = 120;
 export namespace RemoteSourceTrackingService {
   // Constructor Options for RemoteSourceTrackingService.
   export interface Options extends ConfigFile.Options {
@@ -104,6 +109,12 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
     return path.join('.sfdx', 'orgs', orgId, RemoteSourceTrackingService.getFileName());
   }
 
+  /**
+   * Delete the RemoteSourceTracking for a given org.
+   *
+   * @param orgId
+   * @returns the path of the deleted source tracking file
+   */
   public static async delete(orgId: string): Promise<string> {
     const fileToDelete = RemoteSourceTrackingService.getFilePath(orgId);
     // the file might not exist, in which case we don't need to delete it
@@ -233,12 +244,10 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
     this.setServerMaxRevision(0);
     this.initSourceMembers();
 
-    let members: SourceMember[];
-    if (toRevision != null) {
-      members = await this.querySourceMembersTo(toRevision);
-    } else {
-      members = await this.querySourceMembersFrom({ fromRevision: 0 });
-    }
+    const members =
+      toRevision != null
+        ? await this.querySourceMembersTo(toRevision)
+        : await this.querySourceMembersFrom({ fromRevision: 0 });
 
     await this.trackSourceMembers(members, true);
     return members.map((member) => getMetadataKey(member.MemberType, member.MemberName));
@@ -284,6 +293,7 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
   private getTypedContents(): Contents {
     return this.getContents() as unknown as Contents;
   }
+
   // Adds the given SourceMembers to the list of tracked MemberRevisions, optionally updating
   // the lastRetrievedFromServer field (sync), and persists the changes to maxRevision.json.
   public async trackSourceMembers(sourceMembers: SourceMember[], sync = false): Promise<void> {
@@ -300,33 +310,28 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
       // try accessing the sourceMembers object at the index of the change's name
       // if it exists, we'll update the fields - if it doesn't, we'll create and insert it
       const key = getMetadataKey(change.MemberType, change.MemberName);
-      let sourceMember = this.getSourceMember(key);
-      if (sourceMember) {
+      const sourceMember = this.getSourceMember(key) ?? {
+        serverRevisionCounter: change.RevisionCounter,
+        lastRetrievedFromServer: null,
+        memberType: change.MemberType,
+        isNameObsolete: change.IsNameObsolete,
+      };
+      if (sourceMember.lastRetrievedFromServer) {
         // We are already tracking this element so we'll update it
         if (!quiet) {
-          let msg = `Updating ${key} to RevisionCounter: ${change.RevisionCounter}`;
-          if (sync) {
-            msg += ' and syncing';
-          }
-          this.logger.debug(msg);
+          this.logger.debug(
+            `Updating ${key} to RevisionCounter: ${change.RevisionCounter}${sync ? ' and syncing' : ''}`
+          );
         }
         sourceMember.serverRevisionCounter = change.RevisionCounter;
         sourceMember.isNameObsolete = change.IsNameObsolete;
       } else {
         // We are not yet tracking it so we'll insert a new record
         if (!quiet) {
-          let msg = `Inserting ${key} with RevisionCounter: ${change.RevisionCounter}`;
-          if (sync) {
-            msg += ' and syncing';
-          }
-          this.logger.debug(msg);
+          this.logger.debug(
+            `Inserting ${key} with RevisionCounter: ${change.RevisionCounter}${sync ? ' and syncing' : ''}`
+          );
         }
-        sourceMember = {
-          serverRevisionCounter: change.RevisionCounter,
-          lastRetrievedFromServer: null,
-          memberType: change.MemberType,
-          isNameObsolete: change.IsNameObsolete,
-        };
       }
 
       // If we are syncing changes then we need to update the lastRetrievedFromServer field to
@@ -400,52 +405,52 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
       return;
     }
 
-    if (expectedMembers.length === 0) {
+    const outstandingSourceMembers = this.calculateExpectedSourceMembers(expectedMembers);
+    if (expectedMembers.length === 0 || outstandingSourceMembers.size === 0) {
       // Don't bother polling if we're not matching SourceMembers
       return;
     }
 
-    const outstandingSourceMembers = new Map();
-
-    // filter known Source tracking issues
-    expectedMembers
-      .filter(
-        (fileResponse) =>
-          // unchanged files will never be in the sourceMembers.  Not really sure why SDR returns them.
-          fileResponse.state !== ComponentStatus.Unchanged &&
-          // if a listView is the only change inside an object, the object won't have a sourceMember change.  We won't wait for those to be found
-          fileResponse.type !== 'CustomObject' &&
-          // aura meta.xml aren't tracked as SourceMembers
-          !fileResponse.filePath?.endsWith('.cmp-meta.xml')
-      )
-      .map((member) => {
-        getMetadataKeyFromFileResponse(member).map((key) => outstandingSourceMembers.set(key, member));
-      });
-    const originalSize = outstandingSourceMembers.size;
-    const fromRevision = this.getServerMaxRevision();
+    const originalOutstandingSize = outstandingSourceMembers.size;
+    // this will be the absolute timeout from the start of the poll.  We can also exit early if it doesn't look like more results are coming in
     const pollingTimeout = this.calculateTimeout(outstandingSourceMembers.size);
+    let highestRevisionSoFar = this.getServerMaxRevision();
+    let pollAttempts = 0;
+    let consecutiveEmptyResults = 0;
+    let someResultsReturned = false;
+
     this.logger.debug(
-      `Polling for ${outstandingSourceMembers.size} SourceMembers from revision ${fromRevision} with timeout of ${pollingTimeout}s`
+      `Polling for ${outstandingSourceMembers.size} SourceMembers from revision ${highestRevisionSoFar} with timeout of ${pollingTimeout.seconds}s`
     );
 
-    let pollAttempts = 0;
     const poll = async (): Promise<void> => {
       pollAttempts += 1; // not used to stop polling, but for debug logging
 
-      // get sourceMembers since maxRevision
+      // get sourceMembers added since our most recent max
+      // use the "new highest" revision from the last poll that returned results
       const queriedMembers = await this.querySourceMembersFrom({
-        fromRevision,
+        fromRevision: highestRevisionSoFar,
         quiet: pollAttempts !== 1,
         useCache: false,
       });
 
-      // remove anything returned from the query list
-      queriedMembers.map((member) => {
-        outstandingSourceMembers.delete(getMetadataKey(member.MemberType, member.MemberName));
-      });
+      if (queriedMembers.length) {
+        queriedMembers.map((member) => {
+          // remove anything returned from the query list
+          outstandingSourceMembers.delete(getMetadataKey(member.MemberType, member.MemberName));
+          highestRevisionSoFar = Math.max(highestRevisionSoFar, member.RevisionCounter);
+        });
+        consecutiveEmptyResults = 0;
+        // flips on the first batch of results
+        someResultsReturned = true;
+      } else {
+        consecutiveEmptyResults++;
+      }
 
       this.logger.debug(
-        `[${pollAttempts}] Found ${originalSize - outstandingSourceMembers.size} of ${originalSize} SourceMembers`
+        `[${pollAttempts}] Found ${
+          originalOutstandingSize - outstandingSourceMembers.size
+        } of ${originalOutstandingSize} expected SourceMembers`
       );
 
       // update but don't sync
@@ -456,17 +461,20 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
         return;
       }
 
-      if (outstandingSourceMembers.size < 20) {
-        this.logger.debug(
-          outstandingSourceMembers.size < 20
-            ? `Still looking for SourceMembers: ${Array.from(outstandingSourceMembers.keys()).join(',')}`
-            : `Still looking for ${outstandingSourceMembers.size} Source Members`
-        );
+      if (someResultsReturned && consecutiveEmptyResults >= CONSECUTIVE_EMPTY_POLLING_RESULT_LIMIT) {
+        throw new NotRetryableError(`Polling found no results for ${consecutiveEmptyResults} consecutive attempts`);
       }
+
+      this.logger.debug(
+        outstandingSourceMembers.size < 20
+          ? `Still looking for SourceMembers: ${Array.from(outstandingSourceMembers.keys()).join(',')}`
+          : `Still looking for ${outstandingSourceMembers.size} Source Members`
+      );
+
       throw new Error();
     };
     const pollingFunction = retryDecorator(poll, {
-      timeout: pollingTimeout * 1000,
+      timeout: pollingTimeout.milliseconds,
       delay: 1000,
       retries: 'INFINITELY',
     });
@@ -474,7 +482,9 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
       await pollingFunction();
       this.logger.debug(`Retrieved all SourceMember data after ${pollAttempts} attempts`);
     } catch {
-      this.logger.warn(`Polling for SourceMembers timed out after ${pollAttempts} attempts`);
+      this.logger.warn(
+        `Polling for SourceMembers timed out after ${pollAttempts} attempts (last ${consecutiveEmptyResults} were empty) )`
+      );
       if (outstandingSourceMembers.size < 51) {
         this.logger.debug(
           `Could not find ${outstandingSourceMembers.size} SourceMembers: ${Array.from(outstandingSourceMembers).join(
@@ -484,14 +494,63 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
       } else {
         this.logger.debug(`Could not find SourceMembers for ${outstandingSourceMembers.size} components`);
       }
+      void Lifecycle.getInstance().emitTelemetry({
+        eventName: 'sourceMemberPollingTimeout',
+        library: 'SourceTracking',
+        timeoutSeconds: pollingTimeout.seconds,
+        attempts: pollAttempts,
+        consecutiveEmptyResults,
+        missingQuantity: outstandingSourceMembers.size,
+        deploymentSize: expectedMembers.length,
+        types: [...new Set(Array.from(outstandingSourceMembers.values()).map((member) => member.type))]
+          .sort()
+          .join(','),
+        members: Array.from(outstandingSourceMembers.keys()).join(','),
+      });
     }
   }
 
-  private calculateTimeout(memberCount: number): number {
+  private calculateExpectedSourceMembers(expectedMembers: RemoteSyncInput[]): Map<string, RemoteSyncInput> {
+    const outstandingSourceMembers = new Map<string, RemoteSyncInput>();
+
+    // filter known Source tracking issues
+    expectedMembers
+      .filter(
+        (fileResponse) =>
+          // unchanged files will never be in the sourceMembers.  Not really sure why SDR returns them.
+          fileResponse.state !== ComponentStatus.Unchanged &&
+          // if a listView is the only change inside an object, the object won't have a sourceMember change.  We won't wait for those to be found
+          // we don't know which email folder type might be there, so don't require either
+          // Portal doesn't support source tracking, according to the coverage report
+          !['CustomObject', 'EmailFolder', 'EmailTemplateFolder', 'StandardValueSet', 'Portal'].includes(
+            fileResponse.type
+          ) &&
+          // don't wait on workflow children
+          !fileResponse.type.startsWith('Workflow') &&
+          // aura meta.xml aren't tracked as SourceMembers
+          !fileResponse.filePath?.endsWith('.cmp-meta.xml') &&
+          !fileResponse.filePath?.endsWith('.tokens-meta.xml') &&
+          !fileResponse.filePath?.endsWith('.evt-meta.xml')
+      )
+      .map((member) => {
+        getMetadataKeyFromFileResponse(member)
+          // CustomObject could have been added by the key generator
+          // remove some individual members known to not work with tracking even when their type does
+          .filter(
+            (key) =>
+              !key.startsWith('CustomObject') && key !== 'Profile__Standard' && key !== 'CustomTab__standard-home'
+          )
+          .map((key) => outstandingSourceMembers.set(key, member));
+      });
+
+    return outstandingSourceMembers;
+  }
+
+  private calculateTimeout(memberCount: number): Duration {
     const overriddenTimeout = toNumber(env.getString('SFDX_SOURCE_MEMBER_POLLING_TIMEOUT', '0'));
     if (overriddenTimeout > 0) {
       this.logger.debug(`Overriding SourceMember polling timeout to ${overriddenTimeout}`);
-      return overriddenTimeout;
+      return Duration.seconds(overriddenTimeout);
     }
 
     // Calculate a polling timeout for SourceMembers based on the number of
@@ -499,7 +558,7 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
     // wait 50s for each 1000 components, plus 5s.
     const pollingTimeout = Math.ceil(memberCount * 0.05) + 5;
     this.logger.debug(`Computed SourceMember polling timeout of ${pollingTimeout}s`);
-    return pollingTimeout;
+    return Duration.seconds(pollingTimeout);
   }
 
   private async querySourceMembersFrom({

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -542,7 +542,7 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
     }
 
     try {
-      const results = await this.org.getConnection().tooling.autoFetchQuery<T>(query);
+      const results = await this.org.getConnection().tooling.autoFetchQuery<T>(query, { maxFetch: 50000 });
       return results.records;
     } catch (error) {
       throw SfdxError.wrap(error as Error);

--- a/test/unit/metadataKeys.test.ts
+++ b/test/unit/metadataKeys.test.ts
@@ -22,6 +22,19 @@ describe('metadataKeys', () => {
   });
 
   describe('lwc', () => {
+    it('lwc in folder of the same name', () => {
+      const fileResponse = {
+        fullName: 'productTileList',
+        type: 'LightningComponentBundle',
+        state: ComponentStatus.Created,
+        filePath: 'force-app/main/productTileList/lwc/productTileList/productTileList.css',
+      };
+      expect(getMetadataKeyFromFileResponse(fileResponse)).to.deep.equal([
+        'LightningComponentResource__productTileList/productTileList.css',
+        'LightningComponentBundle__productTileList',
+      ]);
+    });
+
     it('lwc returns the bundle and the resource pointing to the file', () => {
       const fileResponse = {
         fullName: 'productTileList',

--- a/test/unit/remoteSourceTracking.test.ts
+++ b/test/unit/remoteSourceTracking.test.ts
@@ -306,7 +306,7 @@ describe('remoteSourceTrackingService', () => {
         expect(trackSpy.callCount).to.equal(6);
         expect(warnSpy.called).to.equal(true);
         const expectedMsg = 'Polling for SourceMembers timed out after 6 attempts';
-        expect(warnSpy.calledOnceWith(expectedMsg)).to.equal(true);
+        expect(warnSpy.calledWithMatch(expectedMsg)).to.equal(true);
         expect(queryStub.called).to.equal(true);
         expect(getServerMaxRevisionStub.calledOnce).to.equal(true);
       }).timeout(10000);
@@ -329,15 +329,11 @@ describe('remoteSourceTrackingService', () => {
         await remoteSourceTrackingService.pollForSourceTracking(memberNames);
         expect(trackSpy.called).to.equal(true);
 
-        // expect(trackSpy.calledOnceWith([], true)).to.equal(true);
         expect(warnSpy.called).to.equal(true);
         const expectedMsg = 'Polling for SourceMembers timed out after 3 attempts';
-        expect(warnSpy.calledOnceWith(expectedMsg)).to.equal(true);
+        expect(warnSpy.calledWithMatch(expectedMsg)).to.equal(true);
         expect(warnSpy.calledOnce).to.equal(true);
-
         expect(queryStub.called).to.equal(true);
-        // expect(queryStub.calledWith(maxRev)).to.equal(true);
-
         expect(getServerMaxRevisionStub.calledOnce).to.equal(true);
       });
     });


### PR DESCRIPTION
### What does this PR do?
bigger queries for sourceMembers
creates a secondary timeout for "after the first batch of sourceMembers are created, how long should I wait on the next batch"?
exclue a bunch of sourceMembers from polling--they can't be the last thing we're waiting on
telemetry for sourceMember polling timeouts (how long, what's missing)
handle issues around foo/lwc/foo/foo.css matching paths wrong

NUTs note: e-bikes changed with the release.  The NUTs in plugin-source are fixed here: https://github.com/salesforcecli/plugin-source/pull/421.  When that PR merges, you should see green here.  Until then, you can run them locally by linking source-tracking into plugin-source first.

### What issues does this PR fix or reference?
fixes at least some of @W-10666968@

QA notes:
DEBUG=* is useful to see what's happening with sourceMemberPolling. You can ctrl-f for `sfdx:RemoteSourceTrackingService` or use `DEBUG=sfdx:RemoteSourceTrackingService` for a filtered log

I did this with 2 dotOrg repos (simulating larger deployments with more interesting types and arrangements).  Both have bugs in them (I opened PRs, but here's my fork where I corrected them)

https://github.com/mshanemc/EDA/tree/translation-errors
```shell
sfdx force:org:delete --noprompt;
sfdx force:org:create -d 1 -s -f orgs/dev.json --nonamespace;
sfdx force:source:deploy -p unpackaged/pre; 
DEBUG=* ../../plugin-source/bin/run force:source:beta:push --forceoverwrite
```

https://github.com/mshanemc/PMM/tree/sm/label-fix
```shell
sfdx force:org:delete --noprompt;
sfdx force:org:create -d 1 -s -f orgs/dev.json --nonamespace;
DEBUG=* ../../plugin-source/bin/run force:source:beta:push      
```






