### PR TITLE
perf: deduplicate files as they are committed to shadow repo

### DIFF
--- a/src/shared/localShadowRepo.ts
+++ b/src/shared/localShadowRepo.ts
@@ -235,11 +235,16 @@ export class ShadowRepo {
       deletedFiles = deletedFiles.map((filepath) => path.normalize(filepath).split(path.sep).join(path.posix.sep));
     }
 
+    const uniqueDeployedFiles = Array.from(new Set(deployedFiles));
+    const uniqueDeletedFiles = Array.from(new Set(deletedFiles));
+
     try {
       // stage changes
       await Promise.all([
-        ...deployedFiles.map((filepath) => git.add({ fs, dir: this.projectPath, gitdir: this.gitDir, filepath })),
-        ...deletedFiles.map((filepath) => git.remove({ fs, dir: this.projectPath, gitdir: this.gitDir, filepath })),
+        ...uniqueDeployedFiles.map((filepath) => git.add({ fs, dir: this.projectPath, gitdir: this.gitDir, filepath })),
+        ...uniqueDeletedFiles.map((filepath) =>
+          git.remove({ fs, dir: this.projectPath, gitdir: this.gitDir, filepath })
+        ),
       ]);
 
       const sha = await git.commit({

--- a/test/unit/localShadowRepo.test.ts
+++ b/test/unit/localShadowRepo.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as git from 'isomorphic-git';
+import { expect } from 'chai';
+import sinon = require('sinon');
+import { ShadowRepo } from '../../src/shared/localShadowRepo';
+
+/* eslint-disable no-unused-expressions */
+
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+
+describe('localShadowRepo', () => {
+  it('does not add same file multiple times', async () => {
+    let projectDir: string;
+    try {
+      projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'localShadowRepoTest'));
+      fs.mkdirSync(path.join(projectDir, 'force-app'));
+      fs.writeFileSync(path.join(projectDir, 'force-app', 'CustomLabels.labels-meta.xml'), '');
+
+      const shadowRepo: ShadowRepo = await ShadowRepo.getInstance({
+        orgId: '00D456789012345',
+        projectPath: projectDir,
+        packageDirs: [
+          {
+            name: 'dummy',
+            fullPath: 'dummy',
+            path: path.join(projectDir, 'force-app'),
+          },
+        ],
+      });
+
+      const gitAdd = sinon.spy(git, 'add');
+
+      const labelsFile = path.join('force-app', 'CustomLabels.labels-meta.xml');
+      const sha = await shadowRepo.commitChanges({ deployedFiles: [labelsFile, labelsFile] });
+
+      expect(sha).to.not.be.empty;
+      expect(gitAdd.calledOnce).to.be.true;
+    } finally {
+      if (projectDir) fs.rmdirSync(projectDir, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
### What does this PR do?

This provides one of the changes from https://github.com/forcedotcom/source-tracking/pull/128 along with a unit test. This is a performance change that stops git.add() being called on the same file many times. In testing a FinancialForce package deploy we observed the CustomLabels files being added many thousands of times and each taking nearly ~200ms (likely due to the file size).

The PR stops this happening by deduplicating the files to add and delete before calling git add/remove on them.

### What issues does this PR fix or reference?

This is one of the problems causing https://github.com/forcedotcom/cli/issues/1394. 

