### PR TITLE
fix: ga tracking commands compatibility

### DIFF
--- a/messages/compatibility.json
+++ b/messages/compatibility.json
@@ -1,5 +1,5 @@
 {
   "sourceTrackingFileVersionMismatch": "This project uses the %s version of source tracking files.",
-  "clearSuggestion": "Clear the %s version of the tracking files by running '%s'",
+  "clearSuggestion": "Pull any changes in your org.  Then, clear the %s version of the tracking files by running '%s' followed by '%s'.",
   "useOtherVersion": "Use the %s version of the command, '%s' with your existing tracking files."
 }

--- a/messages/compatibility.json
+++ b/messages/compatibility.json
@@ -1,5 +1,5 @@
 {
   "sourceTrackingFileVersionMismatch": "This project uses the %s version of source tracking files.",
-  "clearSuggestion": "Pull any changes in your org.  Then, clear the %s version of the tracking files by running '%s' followed by '%s'.",
+  "clearSuggestion": "Push/Pull any local or remote changes.  Then, clear the %s version of the tracking files by running '%s' followed by '%s'.",
   "useOtherVersion": "Use the %s version of the command, '%s' with your existing tracking files."
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@salesforce/core": "^2.33.1",
     "@salesforce/kit": "^1.5.17",
     "@salesforce/source-deploy-retrieve": "^5.9.4",
-    "isomorphic-git": "1.14.0",
+    "isomorphic-git": "1.16.0",
     "ts-retry-promise": "^0.6.0"
   },
   "devDependencies": {

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -73,6 +73,7 @@ export const throwIfInvalid = ({
       )}.\n${messages.getMessage('clearSuggestion', [
         'new/beta',
         replaceRenamedCommands('sfdx force:source:tracking:clear'),
+        replaceRenamedCommands('sfdx force:source:tracking:reset', true),
       ])}.`,
       'SourceTrackingFileVersionMismatch'
     );
@@ -84,7 +85,11 @@ export const throwIfInvalid = ({
       'SourceTrackingFileVersionMismatch',
       [
         messages.getMessage('useOtherVersion', ['old/legacy', replaceRenamedCommands(command, true)]),
-        messages.getMessage('clearSuggestion', ['old/legacy', 'sfdx force:source:tracking:clear']),
+        messages.getMessage('clearSuggestion', [
+          'old/legacy',
+          'sfdx force:source:legacy:tracking:clear',
+          'sfdx force:source:tracking:reset',
+        ]),
       ]
     );
   }
@@ -104,9 +109,9 @@ export const replaceRenamedCommands = (input: string, reverse = false): string =
 };
 
 const renames = new Map([
-  ['force:source:status', 'force:source:beta:status'],
-  ['force:source:push', 'force:source:beta:push'],
-  ['force:source:pull', 'force:source:beta:pull'],
-  ['force:source:tracking:reset', 'force:source:beta:tracking:reset'],
-  ['force:source:tracking:clear', 'force:source:beta:tracking:clear'],
+  ['force:source:legacy:status', 'force:source:status'],
+  ['force:source:legacy:push', 'force:source:push'],
+  ['force:source:legacy:pull', 'force:source:pull'],
+  ['force:source:legacy:tracking:reset', 'force:source:tracking:reset'],
+  ['force:source:legacy:tracking:clear', 'force:source:tracking:clear'],
 ]);

--- a/src/shared/localShadowRepo.ts
+++ b/src/shared/localShadowRepo.ts
@@ -14,7 +14,6 @@ import * as git from 'isomorphic-git';
 import { pathIsInFolder } from './functions';
 
 const gitIgnoreFileName = '.gitignore';
-const stashedGitIgnoreFileName = '.BAK.gitignore';
 /**
  * returns the full path to where we store the shadow repo
  */
@@ -55,7 +54,6 @@ export class ShadowRepo {
   private packageDirs!: NamedPackageDir[];
   private status!: StatusRow[];
   private logger!: Logger;
-  private gitIgnoreLocations: string[] = [];
 
   private constructor(options: ShadowRepoOptions) {
     this.gitDir = getGitDir(options.orgId, options.projectPath);
@@ -81,7 +79,6 @@ export class ShadowRepo {
       this.logger.debug('initializing git repo');
       await this.gitInit();
     }
-    await this.locateIgnoreFiles();
   }
 
   /**
@@ -117,36 +114,32 @@ export class ShadowRepo {
    */
   public async getStatus(noCache = false): Promise<StatusRow[]> {
     if (!this.status || noCache) {
-      try {
-        // only ask about OS once but use twice
-        const isWindows = os.type() === 'Windows_NT';
-        await this.stashIgnoreFile();
-        const filepaths = isWindows
-          ? // iso-git uses posix paths, but packageDirs has already normalized them so we need to convert if windows
-            this.packageDirs.map((dir) => dir.path.split(path.sep).join(path.posix.sep))
-          : this.packageDirs.map((dir) => dir.path);
-        // status hasn't been initalized yet
-        this.status = await git.statusMatrix({
-          fs,
-          dir: this.projectPath,
-          gitdir: this.gitDir,
-          filepaths,
-          filter: (f) =>
-            // no hidden files
-            !f.includes(`${path.sep}.`) &&
-            // no lwc tests
-            !f.includes('__tests__') &&
-            // no gitignore files
-            ![gitIgnoreFileName, stashedGitIgnoreFileName].includes(path.basename(f)) &&
-            // isogit uses `startsWith` for filepaths so it's possible to get a false positive
-            filepaths.some((pkgDir) => pathIsInFolder(f, pkgDir)),
-        });
-        // isomorphic-git stores things in unix-style tree.  Convert to windows-style if necessary
-        if (isWindows) {
-          this.status = this.status.map((row) => [path.normalize(row[FILE]), row[HEAD], row[WORKDIR], row[3]]);
-        }
-      } finally {
-        await this.unStashIgnoreFile();
+      // only ask about OS once but use twice
+      const isWindows = os.type() === 'Windows_NT';
+      const filepaths = isWindows
+        ? // iso-git uses posix paths, but packageDirs has already normalized them so we need to convert if windows
+          this.packageDirs.map((dir) => dir.path.split(path.sep).join(path.posix.sep))
+        : this.packageDirs.map((dir) => dir.path);
+      // status hasn't been initalized yet
+      this.status = await git.statusMatrix({
+        fs,
+        dir: this.projectPath,
+        gitdir: this.gitDir,
+        filepaths,
+        ignored: true,
+        filter: (f) =>
+          // no hidden files
+          !f.includes(`${path.sep}.`) &&
+          // no lwc tests
+          !f.includes('__tests__') &&
+          // no gitignore files
+          !f.endsWith(gitIgnoreFileName) &&
+          // isogit uses `startsWith` for filepaths so it's possible to get a false positive
+          filepaths.some((pkgDir) => pathIsInFolder(f, pkgDir)),
+      });
+      // isomorphic-git stores things in unix-style tree.  Convert to windows-style if necessary
+      if (isWindows) {
+        this.status = this.status.map((row) => [path.normalize(row[FILE]), row[HEAD], row[WORKDIR], row[3]]);
       }
     }
     return this.status;
@@ -227,70 +220,37 @@ export class ShadowRepo {
       return 'no files to commit';
     }
 
-    await this.stashIgnoreFile();
-
     // these are stored in posix/style/path format.  We have to convert inbound stuff from windows
     if (os.type() === 'Windows_NT') {
       deployedFiles = deployedFiles.map((filepath) => path.normalize(filepath).split(path.sep).join(path.posix.sep));
       deletedFiles = deletedFiles.map((filepath) => path.normalize(filepath).split(path.sep).join(path.posix.sep));
     }
-    try {
-      if (deployedFiles.length) {
-        await git.add({ fs, dir: this.projectPath, gitdir: this.gitDir, filepath: [...new Set(deployedFiles)] });
-      }
 
-      for (const filepath of [...new Set(deletedFiles)]) {
-        await git.remove({ fs, dir: this.projectPath, gitdir: this.gitDir, filepath });
-      }
-
-      const sha = await git.commit({
+    if (deployedFiles.length) {
+      await git.add({
         fs,
         dir: this.projectPath,
         gitdir: this.gitDir,
-        message,
-        author: { name: 'sfdx source tracking' },
+        filepath: [...new Set(deployedFiles)],
+        force: true,
       });
-      // status changed as a result of the commit.  This prevents users from having to run getStatus(true) to avoid cache
-      if (needsUpdatedStatus) {
-        await this.getStatus(true);
-      }
-      return sha;
-    } finally {
-      await this.unStashIgnoreFile();
     }
-  }
 
-  private async locateIgnoreFiles(): Promise<void> {
-    // set the gitIgnoreLocations so we only have to do it once
-    this.gitIgnoreLocations = (
-      (await git.walk({
-        fs,
-        dir: this.projectPath,
-        gitdir: this.gitDir,
-        trees: [git.WORKDIR()],
-        // eslint-disable-next-line @typescript-eslint/require-await
-        map: async (filepath: string) => filepath,
-      })) as string[]
-    )
-      .filter((filepath) => filepath.includes(gitIgnoreFileName))
-      .map((ignoreFile) => path.join(this.projectPath, ignoreFile));
-  }
+    for (const filepath of [...new Set(deletedFiles)]) {
+      await git.remove({ fs, dir: this.projectPath, gitdir: this.gitDir, filepath });
+    }
 
-  private async stashIgnoreFile(): Promise<void> {
-    // allSettled allows them to fail (example, the file wasn't where it was expected).
-    await Promise.allSettled(
-      this.gitIgnoreLocations.map((originalLocation) =>
-        fs.promises.rename(originalLocation, originalLocation.replace(gitIgnoreFileName, stashedGitIgnoreFileName))
-      )
-    );
-  }
-
-  private async unStashIgnoreFile(): Promise<void> {
-    // allSettled allows them to fail (example, the file wasn't where it was expected).
-    await Promise.allSettled(
-      this.gitIgnoreLocations.map((originalLocation) =>
-        fs.promises.rename(originalLocation.replace(gitIgnoreFileName, stashedGitIgnoreFileName), originalLocation)
-      )
-    );
+    const sha = await git.commit({
+      fs,
+      dir: this.projectPath,
+      gitdir: this.gitDir,
+      message,
+      author: { name: 'sfdx source tracking' },
+    });
+    // status changed as a result of the commit.  This prevents users from having to run getStatus(true) to avoid cache
+    if (needsUpdatedStatus) {
+      await this.getStatus(true);
+    }
+    return sha;
   }
 }

--- a/test/nuts/local/relativePkgDirs.nut.ts
+++ b/test/nuts/local/relativePkgDirs.nut.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as path from 'path';
+import { TestSession } from '@salesforce/cli-plugins-testkit';
+import { fs } from '@salesforce/core';
+import { expect } from 'chai';
+import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+
+describe('verifies behavior of relative pkgDirs', () => {
+  let session: TestSession;
+  let repo: ShadowRepo;
+
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        sourceDir: path.join('test', 'nuts', 'repros', 'extra-classes'),
+      },
+      authStrategy: 'NONE',
+    });
+  });
+
+  it('initialize the local tracking', async () => {
+    repo = await ShadowRepo.getInstance({
+      orgId: 'fakeOrgId3',
+      projectPath: session.project.dir,
+      packageDirs: [
+        { path: './force-app', name: 'force-app', fullPath: path.join(session.project.dir, './force-app') },
+      ],
+    });
+    // verify the local tracking files/directories
+    expect(fs.existsSync(repo.gitDir));
+  });
+
+  it('should not include files from force-app-extra', async () => {
+    const changedFilenames = await repo.getChangedFilenames();
+    expect(changedFilenames).to.be.an('array').with.length.greaterThan(0);
+    changedFilenames.map((f) => {
+      expect(f).to.not.contain('force-app-extra');
+    });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3382,10 +3382,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-isomorphic-git@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-git/-/isomorphic-git-1.14.0.tgz#989bd4837eee243921085d6638f6fda6a6f4d4ee"
-  integrity sha512-YO9PPLnLLSZRQ/BMwnGZ78eAftaEzhoAAhCiI6zrgUq7NZF2V/lNYVtf2ypes7Bj8+SgOn/HCv1ssIaPw/PYsA==
+isomorphic-git@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-git/-/isomorphic-git-1.16.0.tgz#f4de2fd0e1c78bbbe03230fbefa88a84463e736a"
+  integrity sha512-pyYcMRp0125hmxsagSaAN63WgHd4x+4sR3eJ71+xdIN0aOij0q5ASPIN7jiJissUHx9/FE4dY73pzDehk+Xomw==
   dependencies:
     async-lock "^1.1.0"
     clean-git-ref "^2.0.1"


### PR DESCRIPTION
### What does this PR do?
1. more helpful explanation of what users should do when switching from old to new tracking files
2. changes to support GA of new tracking commands

Notes: NUTs are likely to be failing until the plugin-source PR is in.

### What issues does this PR fix or reference?
[@W-10884581@](https://gus.lightning.force.com/a07EE00000tS431YAC)