### PR TITLE
feat: gracful-fs for EMFILE: too many open files

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@salesforce/core": "^2.33.1",
     "@salesforce/kit": "^1.5.17",
     "@salesforce/source-deploy-retrieve": "^5.9.4",
+    "graceful-fs": "^4.2.9",
     "isomorphic-git": "1.16.0",
     "ts-retry-promise": "^0.6.0"
   },

--- a/src/shared/localShadowRepo.ts
+++ b/src/shared/localShadowRepo.ts
@@ -4,11 +4,10 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-/* eslint-disable no-console */
 
 import * as path from 'path';
 import * as os from 'os';
-import * as fs from 'fs';
+import * as fs from 'graceful-fs';
 import { NamedPackageDir, Logger } from '@salesforce/core';
 import * as git from 'isomorphic-git';
 import { pathIsInFolder } from './functions';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,6 +2943,11 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0,
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
+graceful-fs@^4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"


### PR DESCRIPTION
### What does this PR do?
saw a `EMFILE: too many open files` on windows, so back to `graceful` we go
there's a reset perf NUT that exercises a large commit of all of EDA

### What issues does this PR fix or reference?
[@W-10899802@](https://gus.lightning.force.com/a07EE00000tdwd2YAA)