### PR TITLE
fix: use absolute paths in ComponentSet for matching local source

### DIFF
--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -299,7 +299,7 @@ export class SourceTracking extends AsyncCreatable {
         }))
       );
       const matchingLocalSourceComponentsSet = ComponentSet.fromSource({
-        fsPaths: this.packagesDirs.map((dir) => resolve(dir.path)),
+        fsPaths: this.packagesDirs.map((dir) => resolve(dir.fullPath)),
         include: remoteChangesAsComponentSet,
       });
       if (options.format === 'string') {

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -299,7 +299,7 @@ export class SourceTracking extends AsyncCreatable {
         }))
       );
       const matchingLocalSourceComponentsSet = ComponentSet.fromSource({
-        fsPaths: this.packagesDirs.map((dir) => dir.path),
+        fsPaths: this.packagesDirs.map((dir) => resolve(dir.path)),
         include: remoteChangesAsComponentSet,
       });
       if (options.format === 'string') {


### PR DESCRIPTION
### What does this PR do?
uses absolute paths in the ComponentSet for matching local source to prevent SDR from writing to the wrong locations with relative paths.

### What issues does this PR fix or reference?
@W-0@