### PR TITLE
Sm/polling-optimizations

### DIFF
--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -513,10 +513,13 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
     }
   }
 
+  /**
+   * Filter out known source tracking issues
+   * This prevents the polling from waiting on things that may never return
+   */
   private calculateExpectedSourceMembers(expectedMembers: RemoteSyncInput[]): Map<string, RemoteSyncInput> {
     const outstandingSourceMembers = new Map<string, RemoteSyncInput>();
 
-    // filter known Source tracking issues
     expectedMembers
       .filter(
         (fileResponse) =>

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -539,11 +539,16 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
           ].includes(fileResponse.type) &&
           // don't wait for standard fields on standard objects
           !(fileResponse.type === 'CustomField' && !fileResponse.filePath?.includes('__c')) &&
+          // deleted fields
+          !(fileResponse.type === 'CustomField' && !fileResponse.filePath?.includes('_del__c')) &&
           // they're settings to mdapi, and FooSettings in sourceMembers
           !fileResponse.type.includes('Settings') &&
           // mdapi encodes these, sourceMembers don't have encoding
           !(
-            (fileResponse.type === 'Layout' || fileResponse.type === 'BusinessProcess') &&
+            (fileResponse.type === 'Layout' ||
+              fileResponse.type === 'BusinessProcess' ||
+              fileResponse.type === 'Profile' ||
+              fileResponse.type === 'HomePageLayout') &&
             fileResponse.filePath?.includes('%')
           ) &&
           // namespaced labels and CMDT don't resolve correctly

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -522,6 +522,7 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
 
     expectedMembers
       .filter(
+        // eslint-disable-next-line complexity
         (fileResponse) =>
           // unchanged files will never be in the sourceMembers.  Not really sure why SDR returns them.
           fileResponse.state !== ComponentStatus.Unchanged &&
@@ -544,6 +545,8 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
           !(fileResponse.type === 'CustomField' && !fileResponse.filePath?.includes('__c')) &&
           // deleted fields
           !(fileResponse.type === 'CustomField' && !fileResponse.filePath?.includes('_del__c')) &&
+          // built-in report type ReportType__screen_flows_prebuilt_crt
+          !(fileResponse.type === 'ReportType' && fileResponse.filePath?.includes('screen_flows_prebuilt_crt')) &&
           // they're settings to mdapi, and FooSettings in sourceMembers
           !fileResponse.type.includes('Settings') &&
           // mdapi encodes these, sourceMembers don't have encoding
@@ -551,6 +554,7 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
             (fileResponse.type === 'Layout' ||
               fileResponse.type === 'BusinessProcess' ||
               fileResponse.type === 'Profile' ||
+              fileResponse.type === 'HomePageComponent' ||
               fileResponse.type === 'HomePageLayout') &&
             fileResponse.filePath?.includes('%')
           ) &&


### PR DESCRIPTION
### What does this PR do?
based on telemetry on what keeps polling open the longest, here's three common ones

1. deleted fields (`_del__c`)
2. url-encoded Profile/HomePageLayout/etc
3. a built-in ReportType

### What issues does this PR fix or reference?
@W-11094034@