### PR TITLE
Sm/sdr-events

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,8 @@ jobs:
             yarn
             yarn upgrade @salesforce/source-deploy-retrieve@latest
             yarn upgrade @salesforce/core@v3-beta
+            npx yarn-deduplicate
+            yarn install
       - when:
           condition:
             equal: ['linux', <<parameters.os>>]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 JavaScript library for tracking local and remote Salesforce metadata changes.
 
-**_ UNDER DEVELOPMENT _**
-
 You should use the class named SourceTracking.
 
 Start like this:
@@ -14,7 +12,6 @@ import { SourceTracking } from '@salesforce/source-tracking';
 const tracking = await SourceTracking.create({
   org: this.org, // Org from sfdx-core
   project: this.project, // Project from sfdx-core
-  apiVersion: this.flags.apiversion as string, // can be undefined, will figure it out if you don't allow users to override
 });
 ```
 
@@ -87,26 +84,3 @@ await tracking.updateRemoteTracking(
   false
 );
 ```
-
-## TODO
-
-NUT for tracking file compatibility check logic
-pollSourceMembers should better handle aggregated types. ex:
-
-```txt
-DEBUG Could not find 2 SourceMembers (using ebikes): AuraDefinition__pageTemplate_2_7_3/pageTemplate_2_7_3.cmp-meta.xml,[object Object],CustomObject__Account,[object Object]
-```
-
-### Enhancements
-
-- for updating ST after deploy/retrieve, we need a quick way for those commands to ask, "is this an ST org?" OR a graceful "ifSupported" wrapper for those methods.
-- ensureRemoteTracking could have 2 options in an object
-  1. `ensureQueryHasReturned` which will make sure the query has run at least once
-  2. `forceQuery` will re-query even if the query already ran (cache-buster typically)
-
-### Cleanup
-
-- review commented code
-- review public methods for whether they should be public
-- organize any shared types
-- export top-level stuff

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@salesforce/core": "^3.21.5",
+    "@salesforce/core": "^3.22.1",
     "@salesforce/kit": "^1.5.42",
     "@salesforce/source-deploy-retrieve": "^6.1.0",
     "graceful-fs": "^4.2.9",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@salesforce/core": "^3.21.1",
+    "@salesforce/core": "^3.21.2",
     "@salesforce/kit": "^1.5.42",
     "@salesforce/source-deploy-retrieve": "^6.1.0",
     "graceful-fs": "^4.2.9",

--- a/package.json
+++ b/package.json
@@ -43,15 +43,15 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@salesforce/core": "^3.19.2",
-    "@salesforce/kit": "^1.5.17",
-    "@salesforce/source-deploy-retrieve": "^6.0.1",
+    "@salesforce/core": "^3.21.1",
+    "@salesforce/kit": "^1.5.42",
+    "@salesforce/source-deploy-retrieve": "^6.1.0",
     "graceful-fs": "^4.2.9",
     "isomorphic-git": "1.17.0",
     "ts-retry-promise": "^0.6.0"
   },
   "devDependencies": {
-    "@salesforce/cli-plugins-testkit": "^1.3.7",
+    "@salesforce/cli-plugins-testkit": "^2.3.0",
     "@salesforce/dev-config": "^3.0.0",
     "@salesforce/dev-scripts": "^2.0.0",
     "@salesforce/prettier-config": "^0.0.2",
@@ -63,9 +63,9 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-config-salesforce": "^0.1.6",
+    "eslint-config-salesforce": "^1.0.1",
     "eslint-config-salesforce-license": "^0.1.6",
-    "eslint-config-salesforce-typescript": "^0.2.7",
+    "eslint-config-salesforce-typescript": "^1.0.0",
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "2.25.4",
     "eslint-plugin-jsdoc": "^37.0.1",
@@ -80,7 +80,7 @@
     "sinon": "^10.0.0",
     "ts-node": "^10.1.0",
     "ts-prune": "^0.10.0",
-    "typescript": "^4.4.4"
+    "typescript": "^4.7.4"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@salesforce/core": "^3.19.0",
+    "@salesforce/core": "^3.19.2",
     "@salesforce/kit": "^1.5.17",
     "@salesforce/source-deploy-retrieve": "^6.0.0",
     "graceful-fs": "^4.2.9",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ export {
   ChangeOptions,
   LocalUpdateOptions,
   ChangeResult,
-  ConflictError,
   StatusOutputRow,
+  ConflictResponse,
+  SourceConflictError,
 } from './shared/types';
 export { getKeyFromObject } from './shared/functions';

--- a/src/shared/conflicts.ts
+++ b/src/shared/conflicts.ts
@@ -5,35 +5,38 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { resolve } from 'path';
-import { SfError } from '@salesforce/core';
-import { SourceComponent, ComponentSet, ForceIgnore } from '@salesforce/source-deploy-retrieve';
-import { ConflictResponse, ChangeResult } from './types';
+import { ComponentSet, ForceIgnore } from '@salesforce/source-deploy-retrieve';
+import { ConflictResponse, ChangeResult, SourceConflictError } from './types';
 import { getMetadataKey } from './functions';
 import { populateTypesAndNames } from './populateTypesAndNames';
+
 export const throwIfConflicts = (conflicts: ConflictResponse[]): void => {
   if (conflicts.length > 0) {
-    const conflictError = new SfError('Conflict detected');
+    const conflictError = new SourceConflictError(`${conflicts.length} conflicts detected`, 'SourceConflictError');
     conflictError.setData(conflicts);
+    throw conflictError;
   }
 };
 
-export const findConflictsInComponentSet = (
-  components: SourceComponent[],
-  conflicts: ChangeResult[]
-): ConflictResponse[] => {
+/**
+ *
+ * @param cs ComponentSet to compare
+ * @param conflicts ChangeResult[] representing conflicts from SourceTracking.getConflicts
+ * @returns ConflictResponse[] de-duped and formatted for json or table display
+ */
+export const findConflictsInComponentSet = (cs: ComponentSet, conflicts: ChangeResult[]): ConflictResponse[] => {
   // map do dedupe by name-type-filename
   const conflictMap = new Map<string, ConflictResponse>();
-  const cs = new ComponentSet(components);
   conflicts
     .filter((cr) => cr.name && cr.type && cs.has({ fullName: cr.name, type: cr.type }))
-    .forEach((c) => {
-      c.filenames?.forEach((f) => {
-        conflictMap.set(`${c.name}#${c.type}#${f}`, {
+    .forEach((cr) => {
+      cr.filenames?.forEach((f) => {
+        conflictMap.set(`${cr.name}#${cr.type}#${f}`, {
           state: 'Conflict',
           // the following 2 type assertions are valid because of previous filter statement
           // they can be removed once TS is smarter about filtering
-          fullName: c.name as string,
-          type: c.type as string,
+          fullName: cr.name as string,
+          type: cr.type as string,
           filePath: resolve(f),
         });
       });
@@ -42,7 +45,7 @@ export const findConflictsInComponentSet = (
   return reformattedConflicts;
 };
 
-export const dedupeConflictChangeResults = ({
+export const getDedupedConflictsFromChanges = ({
   localChanges = [],
   remoteChanges = [],
   projectPath,

--- a/src/shared/conflicts.ts
+++ b/src/shared/conflicts.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { resolve } from 'path';
+import { SfError } from '@salesforce/core';
+import { SourceComponent, ComponentSet, ForceIgnore } from '@salesforce/source-deploy-retrieve';
+import { ConflictResponse, ChangeResult } from './types';
+import { getMetadataKey } from './functions';
+import { populateTypesAndNames } from './populateTypesAndNames';
+export const throwIfConflicts = (conflicts: ConflictResponse[]): void => {
+  if (conflicts.length > 0) {
+    const conflictError = new SfError('Conflict detected');
+    conflictError.setData(conflicts);
+  }
+};
+
+export const findConflictsInComponentSet = (
+  components: SourceComponent[],
+  conflicts: ChangeResult[]
+): ConflictResponse[] => {
+  // map do dedupe by name-type-filename
+  const conflictMap = new Map<string, ConflictResponse>();
+  const cs = new ComponentSet(components);
+  conflicts
+    .filter((cr) => cr.name && cr.type && cs.has({ fullName: cr.name, type: cr.type }))
+    .forEach((c) => {
+      c.filenames?.forEach((f) => {
+        conflictMap.set(`${c.name}#${c.type}#${f}`, {
+          state: 'Conflict',
+          // the following 2 type assertions are valid because of previous filter statement
+          // they can be removed once TS is smarter about filtering
+          fullName: c.name as string,
+          type: c.type as string,
+          filePath: resolve(f),
+        });
+      });
+    });
+  const reformattedConflicts = Array.from(conflictMap.values());
+  return reformattedConflicts;
+};
+
+export const dedupeConflictChangeResults = ({
+  localChanges = [],
+  remoteChanges = [],
+  projectPath,
+  forceIgnore,
+}: {
+  localChanges: ChangeResult[];
+  remoteChanges: ChangeResult[];
+  projectPath: string;
+  forceIgnore: ForceIgnore;
+}): ChangeResult[] => {
+  // index the remoteChanges by filename
+  const fileNameIndex = new Map<string, ChangeResult>();
+  const metadataKeyIndex = new Map<string, ChangeResult>();
+  remoteChanges.map((change) => {
+    if (change.name && change.type) {
+      metadataKeyIndex.set(getMetadataKey(change.name, change.type), change);
+    }
+    change.filenames?.map((filename) => {
+      fileNameIndex.set(filename, change);
+    });
+  });
+
+  const conflicts = new Set<ChangeResult>();
+
+  populateTypesAndNames({ elements: localChanges, excludeUnresolvable: true, projectPath, forceIgnore }).map(
+    (change) => {
+      const metadataKey = getMetadataKey(change.name as string, change.type as string);
+      // option 1: name and type match
+      if (metadataKeyIndex.has(metadataKey)) {
+        conflicts.add({ ...(metadataKeyIndex.get(metadataKey) as ChangeResult) });
+      } else {
+        // option 2: some of the filenames match
+        change.filenames?.map((filename) => {
+          if (fileNameIndex.has(filename)) {
+            conflicts.add({ ...(fileNameIndex.get(filename) as ChangeResult) });
+          }
+        });
+      }
+    }
+  );
+  // deeply de-dupe
+  return Array.from(conflicts);
+};

--- a/src/shared/expectedSourceMembers.ts
+++ b/src/shared/expectedSourceMembers.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
+import { getMetadataKeyFromFileResponse } from './metadataKeys';
+import { RemoteSyncInput } from './types';
+
+export const calculateExpectedSourceMembers = (expectedMembers: RemoteSyncInput[]): Map<string, RemoteSyncInput> => {
+  const outstandingSourceMembers = new Map<string, RemoteSyncInput>();
+
+  expectedMembers
+    .filter(
+      // eslint-disable-next-line complexity
+      (fileResponse) =>
+        // unchanged files will never be in the sourceMembers.  Not really sure why SDR returns them.
+        fileResponse.state !== ComponentStatus.Unchanged &&
+        // if a listView is the only change inside an object, the object won't have a sourceMember change.  We won't wait for those to be found
+        // we don't know which email folder type might be there, so don't require either
+        // Portal doesn't support source tracking, according to the coverage report
+        ![
+          'CustomObject',
+          'EmailFolder',
+          'EmailTemplateFolder',
+          'StandardValueSet',
+          'Portal',
+          'StandardValueSetTranslation',
+          'SharingRules',
+          'SharingCriteriaRule',
+          'GlobalValueSetTranslation',
+          'AssignmentRules',
+        ].includes(fileResponse.type) &&
+        // don't wait for standard fields on standard objects
+        !(fileResponse.type === 'CustomField' && !fileResponse.filePath?.includes('__c')) &&
+        // deleted fields
+        !(fileResponse.type === 'CustomField' && !fileResponse.filePath?.includes('_del__c')) &&
+        // built-in report type ReportType__screen_flows_prebuilt_crt
+        !(fileResponse.type === 'ReportType' && fileResponse.filePath?.includes('screen_flows_prebuilt_crt')) &&
+        // they're settings to mdapi, and FooSettings in sourceMembers
+        !fileResponse.type.includes('Settings') &&
+        // mdapi encodes these, sourceMembers don't have encoding
+        !(
+          (fileResponse.type === 'Layout' ||
+            fileResponse.type === 'BusinessProcess' ||
+            fileResponse.type === 'Profile' ||
+            fileResponse.type === 'HomePageComponent' ||
+            fileResponse.type === 'HomePageLayout') &&
+          fileResponse.filePath?.includes('%')
+        ) &&
+        // namespaced labels and CMDT don't resolve correctly
+        !(['CustomLabels', 'CustomMetadata'].includes(fileResponse.type) && fileResponse.filePath?.includes('__')) &&
+        // don't wait on workflow children
+        !fileResponse.type.startsWith('Workflow') &&
+        // aura xml aren't tracked as SourceMembers
+        !fileResponse.filePath?.endsWith('.cmp-meta.xml') &&
+        !fileResponse.filePath?.endsWith('.tokens-meta.xml') &&
+        !fileResponse.filePath?.endsWith('.evt-meta.xml') &&
+        !fileResponse.filePath?.endsWith('.app-meta.xml') &&
+        !fileResponse.filePath?.endsWith('.intf-meta.xml')
+    )
+    .map((member) => {
+      getMetadataKeyFromFileResponse(member)
+        // remove some individual members known to not work with tracking even when their type does
+        .filter(
+          (key) =>
+            // CustomObject could have been re-added by the key generator from one of its fields
+            !key.startsWith('CustomObject') &&
+            key !== 'Profile__Standard' &&
+            key !== 'CustomTab__standard-home' &&
+            key !== 'AssignmentRules__Case' &&
+            key !== 'ListView__CollaborationGroup.All_ChatterGroups'
+        )
+        .map((key) => outstandingSourceMembers.set(key, member));
+    });
+
+  return outstandingSourceMembers;
+};

--- a/src/shared/expectedSourceMembers.ts
+++ b/src/shared/expectedSourceMembers.ts
@@ -20,10 +20,14 @@ const typesToNoPollFor = [
   'SharingCriteriaRule',
   'GlobalValueSetTranslation',
   'AssignmentRules',
+  'InstalledPackage',
 ];
 
+const typesNotToPollForIfNamespace = ['CustomLabels', 'CustomMetadata', 'DuplicateRule', 'WebLink'];
+
 const isEncodedTypeWithPercentSign = (type: string, filePath?: string): boolean =>
-  ['Layout', 'Profile', 'HomePageComponent', 'HomePageLayout'].includes(type) && Boolean(filePath?.includes('%'));
+  ['Layout', 'Profile', 'HomePageComponent', 'HomePageLayout', 'MilestoneType'].includes(type) &&
+  Boolean(filePath?.includes('%'));
 
 // aura xml aren't tracked as SourceMembers
 const isSpecialAuraXml = (filePath?: string): boolean =>
@@ -58,8 +62,7 @@ export const calculateExpectedSourceMembers = (expectedMembers: RemoteSyncInput[
         !fileResponse.type.includes('Settings') &&
         // mdapi encodes these, sourceMembers don't have encoding
         !isEncodedTypeWithPercentSign(fileResponse.type, fileResponse.filePath) &&
-        // namespaced labels and CMDT don't resolve correctly
-        !(['CustomLabels', 'CustomMetadata'].includes(fileResponse.type) && fileResponse.filePath?.includes('__')) &&
+        !(typesNotToPollForIfNamespace.includes(fileResponse.type) && fileResponse.filePath?.includes('__')) &&
         // don't wait on workflow children
         !fileResponse.type.startsWith('Workflow') &&
         !isSpecialAuraXml(fileResponse.filePath)

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { sep, normalize } from 'path';
+import { sep, normalize, isAbsolute, relative } from 'path';
 import { isString } from '@salesforce/ts-types';
 import { SourceComponent } from '@salesforce/source-deploy-retrieve';
 import { RemoteChangeElement, ChangeResult } from './types';
@@ -42,3 +42,6 @@ const nonEmptyStringFilter = (value: string): boolean => {
 // adapted for TS from https://github.com/30-seconds/30-seconds-of-code/blob/master/snippets/chunk.md
 export const chunkArray = <T>(arr: T[], size: number): T[][] =>
   Array.from({ length: Math.ceil(arr.length / size) }, (v, i) => arr.slice(i * size, i * size + size));
+
+export const ensureRelative = (filePath: string, projectPath: string): string =>
+  isAbsolute(filePath) ? relative(projectPath, filePath) : filePath;

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -22,6 +22,8 @@ export const getKeyFromObject = (element: RemoteChangeElement | ChangeResult): s
 };
 
 export const isBundle = (cmp: SourceComponent): boolean => cmp.type.strategies?.adapter === 'bundle';
+export const isLwcLocalOnlyTest = (filePath: string): boolean =>
+  filePath.includes('__utam__') || filePath.includes('__tests__');
 
 /**
  * Verify that a filepath starts exactly with a complete parent path

--- a/src/shared/localComponentSetArray.ts
+++ b/src/shared/localComponentSetArray.ts
@@ -18,8 +18,8 @@ import { isBundle, pathIsInFolder } from './functions';
 
 interface GroupedFileInput {
   packageDirs: NamedPackageDir[];
-  allNonDeletes: string[];
-  allDeletes: string[];
+  nonDeletes: string[];
+  deletes: string[];
 }
 interface GroupedFile {
   path: string;
@@ -33,17 +33,21 @@ export const getGroupedFiles = (input: GroupedFileInput, byPackageDir = false): 
   );
 };
 
-const getSequential = ({ packageDirs, allNonDeletes, allDeletes }: GroupedFileInput): GroupedFile[] =>
+const getSequential = ({ packageDirs, nonDeletes, deletes }: GroupedFileInput): GroupedFile[] =>
   packageDirs.map((pkgDir) => ({
     path: pkgDir.name,
-    nonDeletes: allNonDeletes.filter((f) => pathIsInFolder(f, pkgDir.name)),
-    deletes: allDeletes.filter((f) => pathIsInFolder(f, pkgDir.name)),
+    nonDeletes: nonDeletes.filter((f) => pathIsInFolder(f, pkgDir.name)),
+    deletes: deletes.filter((f) => pathIsInFolder(f, pkgDir.name)),
   }));
 
-const getNonSequential = ({ packageDirs, allNonDeletes, allDeletes }: GroupedFileInput): GroupedFile[] => [
+const getNonSequential = ({
+  packageDirs,
+  nonDeletes: nonDeletes,
+  deletes: deletes,
+}: GroupedFileInput): GroupedFile[] => [
   {
-    nonDeletes: allNonDeletes,
-    deletes: allDeletes,
+    nonDeletes,
+    deletes,
     path: packageDirs.map((dir) => dir.name).join(';'),
   },
 ];

--- a/src/shared/localComponentSetArray.ts
+++ b/src/shared/localComponentSetArray.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as fs from 'fs';
+import { resolve } from 'path';
+import { NamedPackageDir, Logger } from '@salesforce/core';
+import {
+  ComponentSet,
+  MetadataResolver,
+  VirtualTreeContainer,
+  DestructiveChangesType,
+} from '@salesforce/source-deploy-retrieve';
+import { sourceComponentGuard } from './guards';
+import { isBundle, pathIsInFolder } from './functions';
+
+interface GroupedFileInput {
+  packageDirs: NamedPackageDir[];
+  allNonDeletes: string[];
+  allDeletes: string[];
+}
+interface GroupedFile {
+  path: string;
+  nonDeletes: string[];
+  deletes: string[];
+}
+
+export const getGroupedFiles = (input: GroupedFileInput, byPackageDir = false): GroupedFile[] => {
+  return (byPackageDir ? getSequential(input) : getNonSequential(input)).filter(
+    (group) => group.deletes.length || group.nonDeletes.length
+  );
+};
+
+const getSequential = ({ packageDirs, allNonDeletes, allDeletes }: GroupedFileInput): GroupedFile[] =>
+  packageDirs.map((pkgDir) => ({
+    path: pkgDir.name,
+    nonDeletes: allNonDeletes.filter((f) => pathIsInFolder(f, pkgDir.name)),
+    deletes: allDeletes.filter((f) => pathIsInFolder(f, pkgDir.name)),
+  }));
+
+const getNonSequential = ({ packageDirs, allNonDeletes, allDeletes }: GroupedFileInput): GroupedFile[] => [
+  {
+    nonDeletes: allNonDeletes,
+    deletes: allDeletes,
+    path: packageDirs.map((dir) => dir.name).join(';'),
+  },
+];
+
+export const getComponentSets = (groupings: GroupedFile[], sourceApiVersion?: string): ComponentSet[] => {
+  const logger = Logger.childFromRoot('localComponentSetArray');
+
+  // optimistic resolution...some files may not be possible to resolve
+  const resolverForNonDeletes = new MetadataResolver();
+
+  return groupings
+    .map((grouping) => {
+      logger.debug(
+        `building componentSet for ${grouping.path} (deletes: ${grouping.deletes.length} nonDeletes: ${grouping.nonDeletes.length})`
+      );
+
+      const componentSet = new ComponentSet();
+      if (sourceApiVersion) {
+        componentSet.sourceApiVersion = sourceApiVersion;
+      }
+
+      // we need virtual components for the deletes.
+      // TODO: could we use the same for the non-deletes?
+      const resolverForDeletes = new MetadataResolver(undefined, VirtualTreeContainer.fromFilePaths(grouping.deletes));
+
+      grouping.deletes
+        .flatMap((filename) => resolverForDeletes.getComponentsFromPath(filename))
+        .filter(sourceComponentGuard)
+        .map((component) => {
+          // if the component is a file in a bundle type AND there are files from the bundle that are not deleted, set the bundle for deploy, not for delete
+          if (isBundle(component) && component.content && fs.existsSync(component.content)) {
+            // all bundle types have a directory name
+            try {
+              resolverForNonDeletes
+                .getComponentsFromPath(resolve(component.content))
+                .filter(sourceComponentGuard)
+                .map((nonDeletedComponent) => componentSet.add(nonDeletedComponent));
+            } catch (e) {
+              logger.warn(
+                `unable to find component at ${component.content}.  That's ok if it was supposed to be deleted`
+              );
+            }
+          } else {
+            componentSet.add(component, DestructiveChangesType.POST);
+          }
+        });
+
+      grouping.nonDeletes
+        .flatMap((filename) => {
+          try {
+            return resolverForNonDeletes.getComponentsFromPath(resolve(filename));
+          } catch (e) {
+            logger.warn(`unable to resolve ${filename}`);
+            return undefined;
+          }
+        })
+        .filter(sourceComponentGuard)
+        .map((component) => componentSet.add(component));
+
+      return componentSet;
+    })
+    .filter((componentSet) => componentSet.size > 0);
+};

--- a/src/shared/localShadowRepo.ts
+++ b/src/shared/localShadowRepo.ts
@@ -10,7 +10,7 @@ import * as os from 'os';
 import * as fs from 'graceful-fs';
 import { NamedPackageDir, Logger, SfError } from '@salesforce/core';
 import * as git from 'isomorphic-git';
-import { chunkArray, pathIsInFolder } from './functions';
+import { chunkArray, isLwcLocalOnlyTest, pathIsInFolder } from './functions';
 
 /** returns the full path to where we store the shadow repo */
 const getGitDir = (orgId: string, projectPath: string, useSfdxTrackingFiles = false): string => {
@@ -134,7 +134,7 @@ export class ShadowRepo {
           // no hidden files
           !f.includes(`${path.sep}.`) &&
           // no lwc tests
-          !f.includes('__tests__') &&
+          !isLwcLocalOnlyTest(f) &&
           // no gitignore files
           !f.endsWith('.gitignore') &&
           // isogit uses `startsWith` for filepaths so it's possible to get a false positive

--- a/src/shared/localShadowRepo.ts
+++ b/src/shared/localShadowRepo.ts
@@ -233,6 +233,8 @@ export class ShadowRepo {
       const chunks = chunkArray([...new Set(deployedFiles)], this.maxFileAdd);
       for (const chunk of chunks) {
         try {
+          // these need to be done sequentially (it's already batched) because isogit manages file locking
+          // eslint-disable-next-line no-await-in-loop
           await git.add({
             fs,
             dir: this.projectPath,
@@ -253,6 +255,8 @@ export class ShadowRepo {
     }
 
     for (const filepath of [...new Set(deletedFiles)]) {
+      // these need to be done sequentially because isogit manages file locking.  Isogit remove does not support multiple files at once
+      // eslint-disable-next-line no-await-in-loop
       await git.remove({ fs, dir: this.projectPath, gitdir: this.gitDir, filepath });
     }
 

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -13,7 +13,7 @@ import { getMetadataKey } from './functions';
 // See UT for examples of the complexity this must handle
 // keys always use forward slashes, even on Windows
 const pathAfterFullName = (fileResponse: RemoteSyncInput): string =>
-  fileResponse && fileResponse.filePath
+  fileResponse?.filePath
     ? join(
         dirname(fileResponse.filePath).substring(dirname(fileResponse.filePath).lastIndexOf(fileResponse.fullName)),
         basename(fileResponse.filePath)

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -6,6 +6,7 @@
  */
 import { basename, dirname, join, normalize, sep } from 'path';
 import { ComponentSet, RegistryAccess } from '@salesforce/source-deploy-retrieve';
+import { Lifecycle } from '@salesforce/core';
 import { RemoteSyncInput } from './types';
 import { getMetadataKey } from './functions';
 
@@ -76,3 +77,17 @@ export const mappingsForSourceMemberTypesToMetadataType = new Map<string, string
   ['AuraDefinition', 'AuraDefinitionBundle'],
   ['LightningComponentResource', 'LightningComponentBundle'],
 ]);
+
+export const registrySupportsType = (type: string): boolean => {
+  try {
+    if (mappingsForSourceMemberTypesToMetadataType.has(type)) {
+      return true;
+    }
+    // this must use getTypeByName because findType doesn't support addressable child types (ex: customField!)
+    registry.getTypeByName(type);
+    return true;
+  } catch (e) {
+    void Lifecycle.getInstance().emitWarning(`Unable to find type ${type} in registry`);
+    return false;
+  }
+};

--- a/src/shared/populateFilePaths.ts
+++ b/src/shared/populateFilePaths.ts
@@ -69,10 +69,7 @@ export const populateFilePaths = (elements: ChangeResult[], packageDirPaths: str
   );
 
   // make it simpler to find things later
-  const elementMap = new Map<string, ChangeResult>();
-  elements.map((element) => {
-    elementMap.set(getKeyFromObject(element), element);
-  });
+  const elementMap = new Map<string, ChangeResult>(elements.map((e) => [getKeyFromObject(e), e]));
 
   // iterates the local components and sets their filenames
   for (const matchingComponent of matchingLocalSourceComponentsSet.getSourceComponents().toArray()) {

--- a/src/shared/populateFilePaths.ts
+++ b/src/shared/populateFilePaths.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { EOL } from 'os';
+import { Logger } from '@salesforce/core';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ChangeResult } from './types';
+import { metadataMemberGuard } from './guards';
+import { getKeyFromObject, getMetadataKey } from './functions';
+
+const logger = Logger.childFromRoot('SourceTracking.PopulateFilePaths');
+
+/**
+ * Will build a component set, crawling your local directory, to get paths for remote changes
+ *
+ * @param elements ChangeResults that may or may not have filepaths in their filenames parameters
+ * @param packageDirPaths Array of paths from PackageDirectories
+ * @returns
+ */
+export const populateFilePaths = (elements: ChangeResult[], packageDirPaths: string[]): ChangeResult[] => {
+  if (elements.length === 0) {
+    return [];
+  }
+
+  logger.debug('populateFilePaths for change elements', elements);
+  // component set generated from an array of MetadataMember from all the remote changes
+  // but exclude the ones that aren't in the registry
+  const remoteChangesAsMetadataMember = elements
+    .map((element) => {
+      if (typeof element.type === 'string' && typeof element.name === 'string') {
+        return {
+          type: element.type,
+          fullName: element.name,
+        };
+      }
+    })
+    .filter(metadataMemberGuard);
+
+  const remoteChangesAsComponentSet = new ComponentSet(remoteChangesAsMetadataMember);
+
+  logger.debug(` the generated component set has ${remoteChangesAsComponentSet.size.toString()} items`);
+  if (remoteChangesAsComponentSet.size < elements.length) {
+    // there *could* be something missing
+    // some types (ex: LWC) show up as multiple files in the remote changes, but only one in the component set
+    // iterate the elements to see which ones didn't make it into the component set
+    const missingComponents = elements.filter(
+      (element) =>
+        !remoteChangesAsComponentSet.has({ type: element?.type as string, fullName: element?.name as string })
+    );
+    // Throw if anything was actually missing
+    if (missingComponents.length > 0) {
+      throw new Error(
+        `unable to generate complete component set for ${elements
+          .map((element) => `${element.name} (${element.type})`)
+          .join(EOL)}`
+      );
+    }
+  }
+
+  const matchingLocalSourceComponentsSet = ComponentSet.fromSource({
+    fsPaths: packageDirPaths,
+    include: remoteChangesAsComponentSet,
+  });
+  logger.debug(
+    ` local source-backed component set has ${matchingLocalSourceComponentsSet.size.toString()} items from remote`
+  );
+
+  // make it simpler to find things later
+  const elementMap = new Map<string, ChangeResult>();
+  elements.map((element) => {
+    elementMap.set(getKeyFromObject(element), element);
+  });
+
+  // iterates the local components and sets their filenames
+  for (const matchingComponent of matchingLocalSourceComponentsSet.getSourceComponents().toArray()) {
+    if (matchingComponent.fullName && matchingComponent.type.name) {
+      logger.debug(
+        `${matchingComponent.fullName}|${matchingComponent.type.name} matches ${
+          matchingComponent.xml
+        } and maybe ${matchingComponent.walkContent().toString()}`
+      );
+      const key = getMetadataKey(matchingComponent.type.name, matchingComponent.fullName);
+      elementMap.set(key, {
+        ...elementMap.get(key),
+        modified: true,
+        origin: 'remote',
+        filenames: [matchingComponent.xml as string, ...matchingComponent.walkContent()].filter((filename) => filename),
+      });
+    }
+  }
+
+  return Array.from(elementMap.values());
+};

--- a/src/shared/populateTypesAndNames.ts
+++ b/src/shared/populateTypesAndNames.ts
@@ -9,7 +9,7 @@ import { isString } from '@salesforce/ts-types';
 import { MetadataResolver, VirtualTreeContainer, ForceIgnore } from '@salesforce/source-deploy-retrieve';
 import { ChangeResult } from './types';
 import { sourceComponentGuard } from './guards';
-import { ensureRelative } from './functions';
+import { ensureRelative, isLwcLocalOnlyTest } from './functions';
 const logger = Logger.childFromRoot('SourceTracking.PopulateTypesAndNames');
 
 /**
@@ -74,8 +74,8 @@ export const populateTypesAndNames = ({
       const filenamesFromMatchingComponent = [matchingComponent.xml, ...matchingComponent.walkContent()];
       const ignored = filenamesFromMatchingComponent
         .filter(isString)
-        .filter((filename) => !filename.includes('__tests__'))
-        .some((filename) => forceIgnore?.denies(filename));
+        .filter((f) => !isLwcLocalOnlyTest(f))
+        .some((f) => forceIgnore?.denies(f));
       filenamesFromMatchingComponent.map((filename) => {
         if (filename && elementMap.has(filename)) {
           // add the type/name from the componentSet onto the element

--- a/src/shared/populateTypesAndNames.ts
+++ b/src/shared/populateTypesAndNames.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Logger } from '@salesforce/core';
+import { isString } from '@salesforce/ts-types';
+import { MetadataResolver, VirtualTreeContainer, ForceIgnore } from '@salesforce/source-deploy-retrieve';
+import { ChangeResult } from './types';
+import { sourceComponentGuard } from './guards';
+import { ensureRelative } from './functions';
+const logger = Logger.childFromRoot('SourceTracking.PopulateTypesAndNames');
+
+/**
+ * uses SDR to translate remote metadata records into local file paths (which only typically have the filename).
+ *
+ * @input elements: ChangeResult[]
+ * @input projectPath
+ * @input forceIgnore: ForceIgnore.  If provided, result will indicate whether the file is ignored
+ * @input excludeUnresolvable: boolean Filter out components where you can't get the name and type (that is, it's probably not a valid source component)
+ * @input resolveDeleted: constructs a virtualTree instead of the actual filesystem--useful when the files no longer exist
+ */
+export const populateTypesAndNames = ({
+  elements,
+  projectPath,
+  forceIgnore,
+  excludeUnresolvable = false,
+  resolveDeleted = false,
+}: {
+  elements: ChangeResult[];
+  projectPath: string;
+  forceIgnore?: ForceIgnore;
+  excludeUnresolvable?: boolean;
+  resolveDeleted?: boolean;
+}): ChangeResult[] => {
+  if (elements.length === 0) {
+    return [];
+  }
+
+  logger.debug(`populateTypesAndNames for ${elements.length} change elements`);
+  const filenames = elements.flatMap((element) => element.filenames).filter(isString);
+
+  // component set generated from the filenames on all local changes
+  const resolver = new MetadataResolver(
+    undefined,
+    resolveDeleted ? VirtualTreeContainer.fromFilePaths(filenames) : undefined,
+    !!forceIgnore
+  );
+  const sourceComponents = filenames
+    .flatMap((filename) => {
+      try {
+        return resolver.getComponentsFromPath(filename);
+      } catch (e) {
+        logger.warn(`unable to resolve ${filename}`);
+        return undefined;
+      }
+    })
+    .filter(sourceComponentGuard);
+
+  logger.debug(` matching SourceComponents have ${sourceComponents.length} items from local`);
+
+  // make it simpler to find things later
+  const elementMap = new Map<string, ChangeResult>();
+  elements.map((element) => {
+    element.filenames?.map((filename) => {
+      elementMap.set(ensureRelative(filename, projectPath), element);
+    });
+  });
+
+  // iterates the local components and sets their filenames
+  sourceComponents.map((matchingComponent) => {
+    if (matchingComponent?.fullName && matchingComponent?.type.name) {
+      const filenamesFromMatchingComponent = [matchingComponent.xml, ...matchingComponent.walkContent()];
+      const ignored = filenamesFromMatchingComponent
+        .filter(isString)
+        .filter((filename) => !filename.includes('__tests__'))
+        .some((filename) => forceIgnore?.denies(filename));
+      filenamesFromMatchingComponent.map((filename) => {
+        if (filename && elementMap.has(filename)) {
+          // add the type/name from the componentSet onto the element
+          elementMap.set(filename, {
+            origin: 'remote',
+            ...elementMap.get(filename),
+            type: matchingComponent.type.name,
+            name: matchingComponent.fullName,
+            ignored,
+          });
+        }
+      });
+    }
+  });
+  return excludeUnresolvable
+    ? Array.from(new Set(elementMap.values())).filter((changeResult) => changeResult.name && changeResult.type)
+    : Array.from(new Set(elementMap.values()));
+};

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -11,12 +11,12 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { retryDecorator, NotRetryableError } from 'ts-retry-promise';
 import { ConfigFile, Logger, Org, Messages, Lifecycle, SfError } from '@salesforce/core';
-import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
 import { Dictionary, Optional } from '@salesforce/ts-types';
 import { env, Duration } from '@salesforce/kit';
 import { ChangeResult, RemoteChangeElement, MemberRevision, SourceMember, RemoteSyncInput } from './types';
 import { getMetadataKeyFromFileResponse, mappingsForSourceMemberTypesToMetadataType } from './metadataKeys';
 import { getMetadataKey } from './functions';
+import { calculateExpectedSourceMembers } from './expectedSourceMembers';
 // represents the contents of the config file stored in 'maxRevision.json'
 type Contents = {
   serverMaxRevisionCounter: number;
@@ -327,13 +327,10 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
         }
         sourceMember.serverRevisionCounter = change.RevisionCounter;
         sourceMember.isNameObsolete = change.IsNameObsolete;
-      } else {
-        // We are not yet tracking it so we'll insert a new record
-        if (!quiet) {
-          this.logger.debug(
-            `Inserting ${key} with RevisionCounter: ${change.RevisionCounter}${sync ? ' and syncing' : ''}`
-          );
-        }
+      } else if (!quiet) {
+        this.logger.debug(
+          `Inserting ${key} with RevisionCounter: ${change.RevisionCounter}${sync ? ' and syncing' : ''}`
+        );
       }
 
       // If we are syncing changes then we need to update the lastRetrievedFromServer field to
@@ -407,7 +404,7 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
       return;
     }
 
-    const outstandingSourceMembers = this.calculateExpectedSourceMembers(expectedMembers);
+    const outstandingSourceMembers = calculateExpectedSourceMembers(expectedMembers);
     if (expectedMembers.length === 0 || outstandingSourceMembers.size === 0) {
       // Don't bother polling if we're not matching SourceMembers
       return;
@@ -510,80 +507,6 @@ export class RemoteSourceTrackingService extends ConfigFile<RemoteSourceTracking
         members: Array.from(outstandingSourceMembers.keys()).join(','),
       });
     }
-  }
-
-  /**
-   * Filter out known source tracking issues
-   * This prevents the polling from waiting on things that may never return
-   */
-  private calculateExpectedSourceMembers(expectedMembers: RemoteSyncInput[]): Map<string, RemoteSyncInput> {
-    const outstandingSourceMembers = new Map<string, RemoteSyncInput>();
-
-    expectedMembers
-      .filter(
-        // eslint-disable-next-line complexity
-        (fileResponse) =>
-          // unchanged files will never be in the sourceMembers.  Not really sure why SDR returns them.
-          fileResponse.state !== ComponentStatus.Unchanged &&
-          // if a listView is the only change inside an object, the object won't have a sourceMember change.  We won't wait for those to be found
-          // we don't know which email folder type might be there, so don't require either
-          // Portal doesn't support source tracking, according to the coverage report
-          ![
-            'CustomObject',
-            'EmailFolder',
-            'EmailTemplateFolder',
-            'StandardValueSet',
-            'Portal',
-            'StandardValueSetTranslation',
-            'SharingRules',
-            'SharingCriteriaRule',
-            'GlobalValueSetTranslation',
-            'AssignmentRules',
-          ].includes(fileResponse.type) &&
-          // don't wait for standard fields on standard objects
-          !(fileResponse.type === 'CustomField' && !fileResponse.filePath?.includes('__c')) &&
-          // deleted fields
-          !(fileResponse.type === 'CustomField' && !fileResponse.filePath?.includes('_del__c')) &&
-          // built-in report type ReportType__screen_flows_prebuilt_crt
-          !(fileResponse.type === 'ReportType' && fileResponse.filePath?.includes('screen_flows_prebuilt_crt')) &&
-          // they're settings to mdapi, and FooSettings in sourceMembers
-          !fileResponse.type.includes('Settings') &&
-          // mdapi encodes these, sourceMembers don't have encoding
-          !(
-            (fileResponse.type === 'Layout' ||
-              fileResponse.type === 'BusinessProcess' ||
-              fileResponse.type === 'Profile' ||
-              fileResponse.type === 'HomePageComponent' ||
-              fileResponse.type === 'HomePageLayout') &&
-            fileResponse.filePath?.includes('%')
-          ) &&
-          // namespaced labels and CMDT don't resolve correctly
-          !(['CustomLabels', 'CustomMetadata'].includes(fileResponse.type) && fileResponse.filePath?.includes('__')) &&
-          // don't wait on workflow children
-          !fileResponse.type.startsWith('Workflow') &&
-          // aura xml aren't tracked as SourceMembers
-          !fileResponse.filePath?.endsWith('.cmp-meta.xml') &&
-          !fileResponse.filePath?.endsWith('.tokens-meta.xml') &&
-          !fileResponse.filePath?.endsWith('.evt-meta.xml') &&
-          !fileResponse.filePath?.endsWith('.app-meta.xml') &&
-          !fileResponse.filePath?.endsWith('.intf-meta.xml')
-      )
-      .map((member) => {
-        getMetadataKeyFromFileResponse(member)
-          // remove some individual members known to not work with tracking even when their type does
-          .filter(
-            (key) =>
-              // CustomObject could have been re-added by the key generator from one of its fields
-              !key.startsWith('CustomObject') &&
-              key !== 'Profile__Standard' &&
-              key !== 'CustomTab__standard-home' &&
-              key !== 'AssignmentRules__Case' &&
-              key !== 'ListView__CollaborationGroup.All_ChatterGroups'
-          )
-          .map((key) => outstandingSourceMembers.set(key, member));
-      });
-
-    return outstandingSourceMembers;
   }
 
   private calculateTimeout(memberCount: number): Duration {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,6 +6,7 @@
  */
 
 import { FileResponse, SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { SfError } from '@salesforce/core';
 
 export interface ChangeOptions {
   origin: 'local' | 'remote';
@@ -56,17 +57,18 @@ export type SourceMember = {
   ignored?: boolean;
 };
 
-export interface ConflictError {
-  message: string;
-  name: 'conflict';
-  conflicts: ChangeResult[];
-}
-
 export interface ConflictResponse {
   state: 'Conflict';
   fullName: string;
   type: string;
   filePath: string;
 }
+
+export interface SourceConflictError extends SfError {
+  name: 'SourceConflictError';
+  data: ConflictResponse[];
+}
+
+export class SourceConflictError extends SfError implements SourceConflictError {}
 
 export type ChangeOptionType = ChangeResult | SourceComponent | string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -62,4 +62,11 @@ export interface ConflictError {
   conflicts: ChangeResult[];
 }
 
+export interface ConflictResponse {
+  state: 'Conflict';
+  fullName: string;
+  type: string;
+  filePath: string;
+}
+
 export type ChangeOptionType = ChangeResult | SourceComponent | string;

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -122,7 +122,7 @@ export class SourceTracking extends AsyncCreatable {
     ]);
     const sourceApiVersion = projectConfig.sourceApiVersion;
 
-    const [allNonDeletes, allDeletes] = await Promise.all([
+    const [nonDeletes, deletes] = await Promise.all([
       this.localRepo.getNonDeleteFilenames(),
       this.localRepo.getDeleteFilenames(),
     ]);
@@ -131,8 +131,8 @@ export class SourceTracking extends AsyncCreatable {
     const groupings = getGroupedFiles(
       {
         packageDirs: this.packagesDirs,
-        allNonDeletes,
-        allDeletes,
+        nonDeletes,
+        deletes,
       },
       byPackageDir ?? Boolean(projectConfig.pushPackageDirectoriesSequentially)
     ); // if the users specified true or false for the param, that overrides the project config

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -47,8 +47,18 @@ import { populateTypesAndNames } from './shared/populateTypesAndNames';
 export interface SourceTrackingOptions {
   org: Org;
   project: SfProject;
+
+  /** listen for the SDR scoped<Pre|Post><Deploy|Retrieve> events */
   subscribeSDREvents?: boolean;
+
+  /** don't check for conflicts when responding to SDR events.
+   * This property has no effect unless you also set subscribeSDREvents to true.
+   */
   ignoreConflicts?: boolean;
+
+  /** SourceTracking is caching local file statuses.
+   * If you're using STL as part of a long running process (ex: vscode extensions), set this to false
+   */
   ignoreLocalCache?: boolean;
 }
 

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -274,9 +274,26 @@ export class SourceTracking extends AsyncCreatable {
    * @returns local and remote changed metadata
    *
    */
+  // you should use one of these
   public async getChanges(options: ChangeOptions & { format: 'string' }): Promise<string[]>;
   public async getChanges(options: ChangeOptions & { format: 'SourceComponent' }): Promise<SourceComponent[]>;
   public async getChanges(options: ChangeOptions & { format: 'ChangeResult' }): Promise<ChangeResult[]>;
+  // these following three are deprecated, but remain for backward compatibility
+  /**
+   * @deprecated omit the type parameter <string>.
+   */
+  public async getChanges<T extends string>(options: ChangeOptions & { format: 'string' }): Promise<T[]>;
+  /**
+   * @deprecated omit the type parameter <SourceComponent>.
+   */
+  public async getChanges<T extends SourceComponent>(
+    options: ChangeOptions & { format: 'SourceComponent' }
+  ): Promise<T[]>;
+  /**
+   * @deprecated omit the type parameter <ChangeResult>.
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  public async getChanges<T extends ChangeResult>(options: ChangeOptions & { format: 'ChangeResult' }): Promise<T[]>;
   public async getChanges(
     options: ChangeOptions & { format: 'ChangeResultWithPaths' }
   ): Promise<Array<ChangeResult & { filename: string[] }>>;

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -48,7 +48,10 @@ export interface SourceTrackingOptions {
   org: Org;
   project: SfProject;
 
-  /** listen for the SDR scoped<Pre|Post><Deploy|Retrieve> events */
+  /** listen for the SDR scoped<Pre|Post><Deploy|Retrieve> events
+   * `pre` events will check for conflicts and throw if there are any (use ignoreConflicts: true to disable)
+   * `post` events will update tracking files with the results of the deploy/retrieve
+   */
   subscribeSDREvents?: boolean;
 
   /** don't check for conflicts when responding to SDR events.

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -760,21 +760,16 @@ export class SourceTracking extends AsyncCreatable {
 
   private localChangesToOutputRow(input: ChangeResult, localType: 'delete' | 'modify' | 'add'): StatusOutputRow[] {
     this.logger.debug('converting ChangeResult to a row', input);
-
-    const baseObject = {
-      type: input.type ?? '',
-      origin: 'local',
-      state: localType,
-      fullName: input.name ?? '',
-      // ignored property will be set in populateTypesAndNames
-      ignored: input.ignored ?? false,
-    };
+    this.forceIgnore ??= ForceIgnore.findAndCreate(this.project.getDefaultPackage().path);
 
     if (input.filenames) {
       return input.filenames.map((filename) => ({
-        ...baseObject,
+        type: input.type ?? '',
+        state: localType,
+        fullName: input.name ?? '',
         filePath: filename,
         origin: 'local',
+        ignored: this.forceIgnore.denies(filename),
       }));
     }
     throw new Error('no filenames found for local ChangeResult');

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -225,9 +225,20 @@ export class SourceTracking extends AsyncCreatable {
    * @returns StatusOutputRow[]
    */
 
-  public async getStatus({ local, remote }: { local: boolean; remote: boolean }): Promise<StatusOutputRow[]> {
+  public async getStatus({
+    local,
+    remote,
+    useCache = true,
+  }: {
+    local: boolean;
+    remote: boolean;
+    useCache: boolean;
+  }): Promise<StatusOutputRow[]> {
     let results: StatusOutputRow[] = [];
     if (local) {
+      if (!useCache) {
+        await this.reReadLocalTrackingCache();
+      }
       results = results.concat(await this.getLocalStatusRows());
     }
     if (remote) {
@@ -452,6 +463,9 @@ export class SourceTracking extends AsyncCreatable {
     await this.remoteSourceTrackingService.syncSpecifiedElements(fileResponses);
   }
 
+  public async reReadLocalTrackingCache(): Promise<void> {
+    await this.localRepo.getStatus(true);
+  }
   /**
    * If the local tracking shadowRepo doesn't exist, it will be created.
    * Does nothing if it already exists.

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -83,11 +83,10 @@ export class SourceTracking extends AsyncCreatable {
     this.ignoreConflicts = options.ignoreConflicts ?? false;
     this.subscribeSDREvents = options.subscribeSDREvents ?? false;
     this.hasSfdxTrackingFiles = hasSfdxTrackingFiles(this.orgId, this.projectPath);
-    this.maybeSubscribeLifecycleEvents();
   }
 
   public async init(): Promise<void> {
-    // reserved for future use
+    await this.maybeSubscribeLifecycleEvents();
   }
 
   /**
@@ -648,8 +647,8 @@ export class SourceTracking extends AsyncCreatable {
     this.ignoreConflicts = value;
   }
 
-  private maybeSubscribeLifecycleEvents(): void {
-    if (this.subscribeSDREvents && this.org.tracksSource) {
+  private async maybeSubscribeLifecycleEvents(): Promise<void> {
+    if (this.subscribeSDREvents && (await this.org.tracksSource())) {
       const lifecycle = Lifecycle.getInstance();
       // the only thing STL uses pre events for is to check conflicts.  So if you don't care about conflicts, don't listen!
       if (!this.ignoreConflicts) {

--- a/test/nuts/local/tracking-scale.nut.ts
+++ b/test/nuts/local/tracking-scale.nut.ts
@@ -32,9 +32,11 @@ describe(`verify tracking handles an add of ${classCount.toLocaleString()} class
     const classdir = path.join(session.project.dir, 'force-app', 'main', 'default', 'classes');
     for (let d = 0; d < dirCount; d++) {
       const dirName = path.join(classdir, `dir${d}`);
+      // eslint-disable-next-line no-await-in-loop
       await fs.promises.mkdir(dirName);
       for (let c = 0; c < classesPerDir; c++) {
         const className = `x${d}x${c}`;
+        // eslint-disable-next-line no-await-in-loop
         await Promise.all([
           fs.promises.writeFile(
             path.join(dirName, `${className}.cls`),

--- a/test/nuts/mpd.nut.ts
+++ b/test/nuts/mpd.nut.ts
@@ -33,7 +33,7 @@ describe('sourceTracking: localChangesAsComponentSet', () => {
     });
     stl = await getSTLInstance(session);
     // these 2 lines help debug path issues in
-    const stlChanges = await stl.getChanges<string>({ origin: 'local', format: 'string', state: 'nondelete' });
+    const stlChanges = await stl.getChanges({ origin: 'local', format: 'string', state: 'nondelete' });
     expect(stlChanges, stlChanges.join(',')).to.have.length.greaterThan(10);
   });
 

--- a/test/unit/conflicts.test.ts
+++ b/test/unit/conflicts.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { ForceIgnore } from '@salesforce/source-deploy-retrieve';
+import { getDedupedConflictsFromChanges } from '../../src/shared/conflicts';
+import { ChangeResult } from '../../src/shared/types';
+
+const class1Local: ChangeResult = {
+  origin: 'local',
+  name: 'MyClass',
+  type: 'ApexClass',
+  filenames: ['foo/classes/MyClass.cls', 'foo/classes/MyClass.cls-meta.xml'],
+};
+
+describe('conflicts functions', () => {
+  const sandbox = sinon.createSandbox();
+  const forceIgnoreStub = sandbox.stub(ForceIgnore.prototype);
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  describe('filter component set', () => {
+    it('matches a conflict in a component set');
+    it('returns nothing when no matches');
+  });
+  describe('dedupe', () => {
+    it('works on empty changes', () => {
+      expect(
+        getDedupedConflictsFromChanges({
+          localChanges: [],
+          remoteChanges: [],
+          projectPath: 'foo',
+          forceIgnore: forceIgnoreStub,
+        })
+      ).to.deep.equal([]);
+    });
+    it('returns nothing when only 1 side is changed', () => {
+      expect(
+        getDedupedConflictsFromChanges({
+          localChanges: [class1Local],
+          remoteChanges: [],
+          projectPath: 'foo',
+          forceIgnore: forceIgnoreStub,
+        })
+      ).to.deep.equal([]);
+    });
+    it('does not return non-matching changes', () => {
+      expect(
+        getDedupedConflictsFromChanges({
+          localChanges: [class1Local],
+          remoteChanges: [
+            {
+              origin: 'remote',
+              name: 'OtherClass',
+              type: 'ApexClass',
+              filenames: ['foo/classes/OtherClass.cls', 'foo/classes/OtherClass.cls-meta.xml'],
+            },
+          ],
+          projectPath: 'foo',
+          forceIgnore: forceIgnoreStub,
+        })
+      ).to.deep.equal([]);
+    });
+
+    it('de-dupes local and remote change where names match', () => {
+      const { filenames, ...simplifiedResult } = class1Local;
+      expect(
+        getDedupedConflictsFromChanges({
+          localChanges: [class1Local],
+          remoteChanges: [{ origin: 'remote', name: 'MyClass', type: 'ApexClass' }],
+          projectPath: 'foo',
+          forceIgnore: forceIgnoreStub,
+        })
+      ).to.deep.equal([{ ...simplifiedResult, origin: 'remote' }]);
+    });
+  });
+});

--- a/test/unit/conflicts.test.ts
+++ b/test/unit/conflicts.test.ts
@@ -4,10 +4,11 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as path from 'path';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { ForceIgnore } from '@salesforce/source-deploy-retrieve';
-import { getDedupedConflictsFromChanges } from '../../src/shared/conflicts';
+import { ForceIgnore, ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { findConflictsInComponentSet, getDedupedConflictsFromChanges } from '../../src/shared/conflicts';
 import { ChangeResult } from '../../src/shared/types';
 
 const class1Local: ChangeResult = {
@@ -26,8 +27,27 @@ describe('conflicts functions', () => {
   });
 
   describe('filter component set', () => {
-    it('matches a conflict in a component set');
-    it('returns nothing when no matches');
+    it('matches a conflict in a component set', () => {
+      const cs = new ComponentSet([{ fullName: class1Local.name, type: class1Local.type }]);
+      expect(findConflictsInComponentSet(cs, [class1Local])).to.deep.equal([
+        {
+          filePath: path.join(__dirname, '..', '..', class1Local.filenames[0]),
+          fullName: class1Local.name,
+          state: 'Conflict',
+          type: class1Local.type,
+        },
+        {
+          filePath: path.join(__dirname, '..', '..', class1Local.filenames[1]),
+          fullName: class1Local.name,
+          state: 'Conflict',
+          type: class1Local.type,
+        },
+      ]);
+    });
+    it('returns nothing when no matches', () => {
+      const cs = new ComponentSet();
+      expect(findConflictsInComponentSet(cs, [class1Local])).to.deep.equal([]);
+    });
   });
   describe('dedupe', () => {
     it('works on empty changes', () => {

--- a/test/unit/expectedSourceMembers.test.ts
+++ b/test/unit/expectedSourceMembers.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
+import { expect } from 'chai';
+import { calculateExpectedSourceMembers } from '../../src/shared/expectedSourceMembers';
+import { getMetadataKeyFromFileResponse } from '../../src/shared/metadataKeys';
+
+describe('expectedSourceMembers', () => {
+  it('filters out standard fields and deleted fields on standardObjects but returns custom fields on same object ', () => {
+    const input = [
+      {
+        type: 'CustomField',
+        fullName: 'Account.Name',
+        filePath: 'src/objects/Account/fields/Name.field-meta.xml',
+        state: ComponentStatus.Created,
+      },
+      {
+        type: 'CustomField',
+        fullName: 'Account.Deleted_del__c',
+        filePath: 'src/objects/Account/fields/Deleted_del__c.field-meta.xml',
+        state: ComponentStatus.Created,
+      },
+      {
+        type: 'CustomField',
+        fullName: 'Account.Foo__c',
+        filePath: 'src/objects/Account/fields/Foo__c.field-meta.xml',
+        state: ComponentStatus.Created,
+      },
+    ];
+    const result = calculateExpectedSourceMembers(input);
+    expect(result.size).to.equal(1);
+    // fields return object, field for their keys
+    expect(result.get(getMetadataKeyFromFileResponse(input[2]).find((f) => f.startsWith('CustomField')))).to.deep.equal(
+      input[2]
+    );
+  });
+
+  it('omits aura xml types', () => {
+    const input = [
+      {
+        type: 'AuraDefinitionBundle',
+        fullName: 'foo',
+        state: ComponentStatus.Created,
+        filePath: 'src/aura/foo/foo.cmp-meta.xml',
+      },
+    ];
+    const result = calculateExpectedSourceMembers(input);
+    expect(result.size).to.equal(0);
+  });
+
+  it('omits Layout only if it contains a %', () => {
+    const input = [
+      {
+        type: 'Layout',
+        fullName: 'Account.OKLayout',
+        filePath: 'src/layouts/Account-OKLayout.layout-meta.xml',
+        state: ComponentStatus.Created,
+      },
+      {
+        type: 'Layout',
+        fullName: 'Account.Whate%ver',
+        filePath: 'src/layouts/Account-Whate%ver.layout-meta.xml',
+        state: ComponentStatus.Created,
+      },
+    ];
+    const result = calculateExpectedSourceMembers(input);
+    expect(result.size).to.equal(1);
+    expect(result.get(getMetadataKeyFromFileResponse(input[0])[0])).to.deep.equal(input[0]);
+  });
+
+  it('omits namespaced custom labels', () => {
+    const input = [
+      {
+        type: 'CustomLabels',
+        fullName: 'ns__Test1',
+        filePath: 'src/labels/ns__Account-OKLayout.labels-meta.xml',
+        state: ComponentStatus.Created,
+      },
+    ];
+    const result = calculateExpectedSourceMembers(input);
+    expect(result.size).to.equal(0);
+  });
+
+  it('omits standard profile', () => {
+    const input = [
+      {
+        type: 'Profile',
+        fullName: 'Standard',
+        filePath: 'src/profiles/Standard.profile-meta.xml',
+        state: ComponentStatus.Created,
+      },
+    ];
+    const result = calculateExpectedSourceMembers(input);
+    expect(result.size).to.equal(0);
+  });
+});

--- a/test/unit/localComponentSetArray.test.ts
+++ b/test/unit/localComponentSetArray.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import { getGroupedFiles } from '../../src/shared/localComponentSetArray';
+
+const packageDirs = [
+  { name: 'one', fullPath: 'test/path/one', path: 'one' },
+  { name: 'two', fullPath: 'test/path/two', path: 'two' },
+];
+
+describe('groupings', () => {
+  it('returns multiple groupings by pkgDir for sequential', () => {
+    const result = getGroupedFiles(
+      {
+        packageDirs,
+        nonDeletes: ['one/file1.xml', 'two/file2.xml'],
+        deletes: ['one/delete.xml', 'two/delete.xml'],
+      },
+      true
+    );
+
+    expect(result).to.deep.equal([
+      {
+        path: 'one',
+        nonDeletes: ['one/file1.xml'],
+        deletes: ['one/delete.xml'],
+      },
+      {
+        path: 'two',
+        nonDeletes: ['two/file2.xml'],
+        deletes: ['two/delete.xml'],
+      },
+    ]);
+  });
+  it('returns one big grouping when not sequential', () => {
+    const result = getGroupedFiles({
+      packageDirs,
+      nonDeletes: ['one/file1.xml', 'two/file2.xml'],
+      deletes: ['one/delete.xml', 'two/delete.xml'],
+    });
+
+    expect(result).to.deep.equal([
+      {
+        path: 'one;two',
+        nonDeletes: ['one/file1.xml', 'two/file2.xml'],
+        deletes: ['one/delete.xml', 'two/delete.xml'],
+      },
+    ]);
+  });
+  it('ignored stuff outside pkgDirs for sequential', () => {
+    const result = getGroupedFiles(
+      {
+        packageDirs,
+        nonDeletes: ['one/file1.xml', 'three/file2.xml'],
+        deletes: ['one/delete.xml', 'three/delete.xml'],
+      },
+      true
+    );
+
+    expect(result).to.deep.equal([
+      {
+        path: 'one',
+        nonDeletes: ['one/file1.xml'],
+        deletes: ['one/delete.xml'],
+      },
+    ]);
+  });
+  describe('filters', () => {
+    it('retains deploy-only groupings', () => {
+      const result = getGroupedFiles({
+        packageDirs,
+        nonDeletes: ['one/file1.xml', 'two/file2.xml'],
+        deletes: [],
+      });
+
+      expect(result).to.deep.equal([
+        {
+          path: 'one;two',
+          nonDeletes: ['one/file1.xml', 'two/file2.xml'],
+          deletes: [],
+        },
+      ]);
+    });
+    it('retains delete-only groupings', () => {
+      const result = getGroupedFiles({
+        packageDirs,
+        deletes: ['one/file1.xml', 'two/file2.xml'],
+        nonDeletes: [],
+      });
+
+      expect(result).to.deep.equal([
+        {
+          path: 'one;two',
+          deletes: ['one/file1.xml', 'two/file2.xml'],
+          nonDeletes: [],
+        },
+      ]);
+    });
+    it('filters out empty groupings', () => {
+      expect(
+        getGroupedFiles({
+          packageDirs,
+          nonDeletes: [],
+          deletes: [],
+        })
+      ).to.have.length(0);
+    });
+  });
+});

--- a/test/unit/metadataKeys.test.ts
+++ b/test/unit/metadataKeys.test.ts
@@ -4,10 +4,10 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { Lifecycle } from '@salesforce/core';
 import { expect } from 'chai';
 import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
-import { getMetadataKeyFromFileResponse } from '../../src/shared/metadataKeys';
+import { getMetadataKeyFromFileResponse, registrySupportsType } from '../../src/shared/metadataKeys';
 
 describe('metadataKeys', () => {
   it('default behavior', () => {
@@ -105,5 +105,26 @@ describe('metadataKeys', () => {
         'EmailTemplateFolder__ETF_WTF',
       ]);
     });
+  });
+});
+
+describe('registrySupportsType', () => {
+  it('custom mapped types', () => {
+    expect(registrySupportsType('AuraDefinition')).to.equal(true);
+    expect(registrySupportsType('LightningComponentResource')).to.equal(true);
+  });
+  it('other real types types', () => {
+    expect(registrySupportsType('CustomObject')).to.equal(true);
+    expect(registrySupportsType('ApexClass')).to.equal(true);
+  });
+  it('bad type returns false and emits warning', () => {
+    let warningEmitted = false;
+    const badType = 'NotARealType';
+    // eslint-disable-next-line @typescript-eslint/require-await
+    Lifecycle.getInstance().onWarning(async (w): Promise<void> => {
+      warningEmitted = w.includes(badType);
+    });
+    expect(registrySupportsType(badType)).to.equal(false);
+    expect(warningEmitted, 'warning not emitted').to.equal(true);
   });
 });

--- a/test/unit/remoteSourceTracking.test.ts
+++ b/test/unit/remoteSourceTracking.test.ts
@@ -40,7 +40,7 @@ const getMemberRevisionEntries = (revision: number, synced = false): { [key: str
   return sourceMemberEntries;
 };
 
-describe.skip('remoteSourceTrackingService', () => {
+describe('remoteSourceTrackingService', () => {
   const username = 'foo@bar.com';
   const orgId = '00D456789012345';
   const $$ = instantiateContext();

--- a/test/unit/remoteSourceTracking.test.ts
+++ b/test/unit/remoteSourceTracking.test.ts
@@ -40,7 +40,7 @@ const getMemberRevisionEntries = (revision: number, synced = false): { [key: str
   return sourceMemberEntries;
 };
 
-describe('remoteSourceTrackingService', () => {
+describe.skip('remoteSourceTrackingService', () => {
   const username = 'foo@bar.com';
   const orgId = '00D456789012345';
   const $$ = instantiateContext();

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,6 +712,31 @@
     mkdirp "1.0.4"
     ts-retry-promise "^0.6.0"
 
+"@salesforce/core@^3.21.2":
+  version "3.21.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.21.2.tgz#7c01d0307830d8af2ad63970c23264863f280142"
+  integrity sha512-B8Qe2qeS0RsPg8nzMNA7SB6grgJOEJTVET8gyOfhEsfdYpgKH0XVn8ox+gCAha4bdj2ebiDrba7IeMMx7nl7Mw==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.5.41"
+    "@salesforce/schemas" "^1.1.0"
+    "@salesforce/ts-types" "^1.5.20"
+    "@types/graceful-fs" "^4.1.5"
+    "@types/mkdirp" "^1.0.2"
+    "@types/semver" "^7.3.9"
+    ajv "^8.11.0"
+    archiver "^5.3.0"
+    change-case "^4.1.2"
+    debug "^3.2.7"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    graceful-fs "^4.2.9"
+    js2xmlparser "^4.0.1"
+    jsforce "2.0.0-beta.11"
+    jsonwebtoken "8.5.1"
+    mkdirp "1.0.4"
+    ts-retry-promise "^0.6.0"
+
 "@salesforce/dev-config@^3.0.0":
   version "3.0.1"
   resolved "https://registry.npmjs.org/@salesforce/dev-config/-/dev-config-3.0.1.tgz#631a952abfd69e7cdb0fb312ba4b1656ae632b90"
@@ -3797,6 +3822,32 @@ jsforce@2.0.0-beta.10:
   version "2.0.0-beta.10"
   resolved "https://registry.npmjs.org/jsforce/-/jsforce-2.0.0-beta.10.tgz#c33fee5dd01c96d121235cffb8fee1458a35423e"
   integrity sha512-AFigJHQocj8t36Eu+9XffoKoC2FO4/uMDMg08TfTXgvIp53lzvnQJoQrhEnwnKReof4tO2d+7j+d1QyiOa2yGg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@babel/runtime-corejs3" "^7.12.5"
+    "@types/node" "^12.19.9"
+    abort-controller "^3.0.0"
+    base64url "^3.0.1"
+    commander "^4.0.1"
+    core-js "^3.6.4"
+    csv-parse "^4.8.2"
+    csv-stringify "^5.3.4"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    fs-extra "^8.1.0"
+    https-proxy-agent "^5.0.0"
+    inquirer "^7.0.0"
+    multistream "^3.1.0"
+    node-fetch "^2.6.1"
+    open "^7.0.0"
+    regenerator-runtime "^0.13.3"
+    strip-ansi "^6.0.0"
+    xml2js "^0.4.22"
+
+jsforce@2.0.0-beta.11:
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.11.tgz#3bce7a91aee425e72392057bb3fda53b6b2b829f"
+  integrity sha512-K/4F7mqMya2mnT16aFvd743MMQCA7MfXR85aKd1V87b2Ol/MDzfxTDwXWC8iXWDjTCT7KkZtcYMnY7ZxqbUOQA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,13 +606,13 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/cli-plugins-testkit@^1.3.7":
-  version "1.5.20"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-1.5.20.tgz#0b43a31efaf54403a2faa137226bcf7a294dccc9"
-  integrity sha512-RkjvjuixhRoUIKbVi4pO9XIg3a+tvompKZtshT01M/+w9bYBIDGPw+PphbyAgvQfikr3N2DEVH/Rw1lQ/gIDFQ==
+"@salesforce/cli-plugins-testkit@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-2.3.0.tgz#fabc0d60e3d63c158405153d45917464da349482"
+  integrity sha512-96vZC+fpJdcnZGLfj7U1PKKgFxa01+ZcSIxydB5qZFu5XYmWjg3C3ah3nlSlIo7RRcM3qhthmeZWRERLsz04zA==
   dependencies:
-    "@salesforce/core" "^2.24.0"
-    "@salesforce/kit" "^1.5.13"
+    "@salesforce/core" "^3.20.1"
+    "@salesforce/kit" "^1.5.42"
     "@salesforce/ts-types" "^1.5.17"
     archiver "^5.2.0"
     debug "^4.3.1"
@@ -620,59 +620,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.6.0"
 
-"@salesforce/core@^2.24.0":
-  version "2.36.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.36.0.tgz#eadade3d663f0a2e11d0cc9f9097c528c182997d"
-  integrity sha512-VsKt7SXArxrOelaJl5Ez21Pmtdp2eU6qimqZ5clxnNaZDZKOySDPYnKHu7AYCt1LUNFN9cfsX8K5yOHxS+wT+w==
-  dependencies:
-    "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.5.17"
-    "@salesforce/schemas" "^1.0.1"
-    "@salesforce/ts-types" "^1.5.20"
-    "@types/graceful-fs" "^4.1.5"
-    "@types/jsforce" "^1.9.41"
-    "@types/mkdirp" "^1.0.1"
-    archiver "^5.3.0"
-    debug "^3.1.0"
-    faye "^1.4.0"
-    graceful-fs "^4.2.4"
-    js2xmlparser "^4.0.1"
-    jsen "0.6.6"
-    jsforce "^1.11.0"
-    jsonwebtoken "8.5.0"
-    mkdirp "1.0.4"
-    semver "^7.3.5"
-    ts-retry-promise "^0.6.0"
-
-"@salesforce/core@^3.19.0":
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.19.0.tgz#e238b07190623dc4e1ca1888c1185f5bfa2d383e"
-  integrity sha512-64bz7cvfEkJz1JCMlf3W1CaWShoaINzfkrT6BQxtb5AdjZm5rs8Lmg3q6hie4hhWo3VVSvPOdnWEPpMJCdJ4/w==
-  dependencies:
-    "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.5.41"
-    "@salesforce/schemas" "^1.1.0"
-    "@salesforce/ts-types" "^1.5.20"
-    "@types/graceful-fs" "^4.1.5"
-    "@types/mkdirp" "^1.0.2"
-    "@types/semver" "^7.3.9"
-    ajv "^8.11.0"
-    archiver "^5.3.0"
-    change-case "^4.1.2"
-    debug "^3.2.7"
-    faye "^1.4.0"
-    form-data "^4.0.0"
-    graceful-fs "^4.2.9"
-    js2xmlparser "^4.0.1"
-    jsforce "2.0.0-beta.10"
-    jsonwebtoken "8.5.1"
-    mkdirp "1.0.4"
-    ts-retry-promise "^0.6.0"
-
-"@salesforce/core@^3.19.2":
-  version "3.19.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.19.2.tgz#45b55fec4425ec9a447aba682a0add084c8ba73a"
-  integrity sha512-uz2ehET9zz8WJj9Gicui3zxSN34TsmjgxrP22XCdQS7/GNhye1SlV8a6ayyQLqJbYlANrPFAs1RhF6LV1mPokg==
+"@salesforce/core@^3.20.1", "@salesforce/core@^3.21.1":
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.21.1.tgz#3e51454d6e5f5fbf523e0372378210b8cf85f60f"
+  integrity sha512-TdOhTeXrfUhRsqqwQKQsA410uBvHsRQiD66wtC0lmUGHRBNxUYEmK6+zbMvVLyPLo6Db4GOPuZ/3DV839fIVBg==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.41"
@@ -739,19 +690,19 @@
     typedoc-plugin-missing-exports "0.22.6"
     typescript "^4.1.3"
 
-"@salesforce/kit@^1.5.13", "@salesforce/kit@^1.5.17":
-  version "1.5.36"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.5.36.tgz#fa9950fb70520fc33352d5184cec5815463f6ff1"
-  integrity sha512-g1IgZID3q7Ehi4x9rIQNOROcsqHVatZgUr36SyXOhADUhqWhRmoUaQq0W0XlAMQr18rrOSct1nviJwHmlqy//A==
+"@salesforce/kit@^1.5.41":
+  version "1.5.41"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.5.41.tgz#3248d4d28fe24ed47827716cfe416c21a2a90651"
+  integrity sha512-nhi7jw3LNITl7rHSnCLnEDTaq6nvolSMFBg7poniG84Q7kJPezgTEj5OKAyQ9hJoRE4u59n5M5bUFvwRoXmJzQ==
   dependencies:
     "@salesforce/ts-types" "^1.5.20"
     shx "^0.3.3"
     tslib "^2.2.0"
 
-"@salesforce/kit@^1.5.41":
-  version "1.5.41"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.5.41.tgz#3248d4d28fe24ed47827716cfe416c21a2a90651"
-  integrity sha512-nhi7jw3LNITl7rHSnCLnEDTaq6nvolSMFBg7poniG84Q7kJPezgTEj5OKAyQ9hJoRE4u59n5M5bUFvwRoXmJzQ==
+"@salesforce/kit@^1.5.42":
+  version "1.5.42"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.5.42.tgz#2c9f5fe9908723a70b65181526c5199e6bb943c5"
+  integrity sha512-40QiPR+bg3iOC2lqCKwVO0iPw29lHCS5KzUZFiTOeu8HDu5SCgDhGc1d1Bj8KK/ZYDrAcNTZ8ObrlQFnme3fdQ==
   dependencies:
     "@salesforce/ts-types" "^1.5.20"
     shx "^0.3.3"
@@ -762,22 +713,22 @@
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.2.tgz#ded39bf7cb75238edc9db6dd093649111350f8bc"
   integrity sha512-KExM355BLbxCW6siGBV7oUOotXvvVp0tAWERgzUkM2FcMb9fWrjwXDrIHc8V0UdDlA3UXtFltDWgN+Yqi+BA/g==
 
-"@salesforce/schemas@^1.0.1", "@salesforce/schemas@^1.1.0":
+"@salesforce/schemas@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.1.0.tgz#bbf94a11ee036f2b0ec6ba82306cd9565a6ba26b"
   integrity sha512-6D7DvE6nFxpLyyTnrOIbbAeCJw2r/EpinFAcMh6gU0gA/CGfSbwV/8uR3uHLYL2zCyCZLH8jJ4dZ3BzCMqc+Eg==
 
-"@salesforce/source-deploy-retrieve@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-6.0.1.tgz#f358d256cc21a32140a33e1ee0c154f0a838176f"
-  integrity sha512-JRoZkS2PTIKklCxbegUnC+wa3n5tTFP+7gBPaYXFd34IRm3JTTAzqTMSEHoHWM1+gUj6OgAup1tfKcJFfyxLrQ==
+"@salesforce/source-deploy-retrieve@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-6.1.0.tgz#4cea1206b9f179ff217cf283657d3d231610c673"
+  integrity sha512-r6XRsznFshjbl9luRRHG8da2QtKSGM6dvW8IpFPReA4PzdyLVlkEVp89jLFK5UmnbqKGfA8QPd31Ajh38DlSWg==
   dependencies:
-    "@salesforce/core" "^3.19.0"
+    "@salesforce/core" "^3.21.1"
     "@salesforce/kit" "^1.5.41"
     "@salesforce/ts-types" "^1.5.20"
     archiver "^5.3.0"
     fast-xml-parser "^3.17.4"
-    got "^11.8.2"
+    got "^11.8.5"
     graceful-fs "^4.2.8"
     ignore "^5.1.8"
     mime "2.6.0"
@@ -945,13 +896,6 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
 
-"@types/jsforce@^1.9.41":
-  version "1.9.41"
-  resolved "https://registry.yarnpkg.com/@types/jsforce/-/jsforce-1.9.41.tgz#08b31a0d04e14fd5f8a232196e16bc742e22bbed"
-  integrity sha512-J0dReK6EPGR98b4fAowqqQqFXH4DGtPxY2lLrZGcuCthrHYkYNrKnfGf2xM1jwiBC5CGdSEDmWEDwRwwmX25tA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/json-buffer@~3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/json-buffer/-/json-buffer-3.0.0.tgz#85c1ff0f0948fc159810d4b5be35bf8c20875f64"
@@ -984,7 +928,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/mkdirp@^1.0.1", "@types/mkdirp@^1.0.2":
+"@types/mkdirp@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.2.tgz#8d0bad7aa793abe551860be1f7ae7f3198c16666"
   integrity sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==
@@ -1178,7 +1122,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1375,22 +1319,10 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@*, asap@~2.0.3:
+asap@*:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
-asn1@~0.2.3:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
-  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
-  dependencies:
-    safer-buffer "~2.1.0"
-
-assert-plus@1.0.0, assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
 assertion-error@^1.1.0:
   version "1.1.0"
@@ -1417,16 +1349,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
-
-aws4@^1.8.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
-  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -1437,22 +1359,10 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-base64-url@^2.2.0:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/base64-url/-/base64-url-2.3.3.tgz#645b71455c75109511f27d98450327e455f488ec"
-  integrity sha512-dLMhIsK7OplcDauDH/tZLvK7JmUZK3A7KiQpjNzsBrM6Etw7hzNI1tLEywqJk9NnwkgWuFKSlx/IUO7vF6Mo8Q==
-
 base64url@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
   integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
-
-bcrypt-pbkdf@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
-  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
-  dependencies:
-    tweetnacl "^0.14.3"
 
 big-integer@^1.6.17:
   version "1.6.49"
@@ -1644,11 +1554,6 @@ cardinal@^2.1.1:
   dependencies:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
-
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 chai@^4.2.0, chai@^4.3.0:
   version "4.3.6"
@@ -1849,24 +1754,12 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-co-prompt@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/co-prompt/-/co-prompt-1.0.0.tgz#fb370e9edac48576b27a732fe5d7f21d9fc6e6f6"
-  integrity sha1-+zcOntrEhXayenMv5dfyHZ/G5vY=
-  dependencies:
-    keypress "~0.2.1"
-
 code-block-writer@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-11.0.0.tgz#5956fb186617f6740e2c3257757fea79315dd7d4"
   integrity sha512-GEqWvEWWsOvER+g9keO4ohFoD3ymwyCnqY3hoTr7GZipYFwEhMHJw+TtV0rfgRhNImM6QWZGO2XYjlJVyYT62w==
   dependencies:
     tslib "2.3.1"
-
-coffeescript@^1.10.0:
-  version "1.12.7"
-  resolved "https://registry.yarnpkg.com/coffeescript/-/coffeescript-1.12.7.tgz#e57ee4c4867cf7f606bfc4a0f2d550c0981ddd27"
-  integrity sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -1902,17 +1795,12 @@ colors@^1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@^2.9.0:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^4.0.1:
   version "4.1.1"
@@ -1988,7 +1876,7 @@ compress-commons@^4.1.0:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 constant-case@^3.0.4:
   version "3.0.4"
@@ -2055,11 +1943,6 @@ core-js@^3.6.4:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.4.tgz#f4b3f108d45736935aa028444a69397e40d8c531"
   integrity sha512-1uLykR+iOfYja+6Jn/57743gc9n73EWiOnSJJ4ba3B4fOEYDBv25MagmEZBxTp5cWq4b/KPx/l77zgsp28ju4w==
 
-core-util-is@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
-
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -2124,17 +2007,10 @@ csprng@*:
   dependencies:
     sequin "*"
 
-csv-parse@^4.10.1, csv-parse@^4.8.2:
+csv-parse@^4.8.2:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.16.3.tgz#7ca624d517212ebc520a36873c3478fa66efbaf7"
   integrity sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==
-
-csv-stringify@^1.0.4:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-1.1.2.tgz#77a41526581bce3380f12b00d7c5bbac70c82b58"
-  integrity sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=
-  dependencies:
-    lodash.get "~4.4.2"
 
 csv-stringify@^5.3.4:
   version "5.6.5"
@@ -2174,13 +2050,6 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
-dashdash@^1.12.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
-  dependencies:
-    assert-plus "^1.0.0"
-
 dayjs-plugin-utc@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dayjs-plugin-utc/-/dayjs-plugin-utc-0.1.2.tgz#48e552407024143922d6499a40f6c765f8c93d03"
@@ -2191,14 +2060,14 @@ dayjs@^1.8.16:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
   integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
 
-debug@4:
+debug@4, debug@^4.1.1, debug@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
-debug@4.3.3, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
+debug@4.3.3, debug@^4.0.1, debug@^4.1.0, debug@^4.3.1, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -2212,7 +2081,7 @@ debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.7:
+debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -2257,9 +2126,9 @@ deep-eql@^3.0.1:
     type-detect "^4.0.0"
 
 deep-is@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 default-require-extensions@^3.0.0:
   version "3.0.0"
@@ -2369,14 +2238,6 @@ duplexer2@~0.1.4:
   integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
   dependencies:
     readable-stream "^2.0.2"
-
-ecc-jsbn@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
-  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
-  dependencies:
-    jsbn "~0.1.0"
-    safer-buffer "^2.1.0"
 
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
@@ -2493,10 +2354,20 @@ eslint-config-salesforce-typescript@^0.2.7:
   resolved "https://registry.yarnpkg.com/eslint-config-salesforce-typescript/-/eslint-config-salesforce-typescript-0.2.8.tgz#73cbc0e87a30118407d455feabf154fd251f7002"
   integrity sha512-CDPcYWIfEVJFbcNG6IdhKW3whp0MujjuM4uRFESQ1Eq4cO8bMbZrwbLypUWxdMgZz7Ua3luMHmIKgkmR4k9FSg==
 
+eslint-config-salesforce-typescript@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-salesforce-typescript/-/eslint-config-salesforce-typescript-1.0.0.tgz#7bc7aa49779cfb395ad8dcfc6481c54d4a68b35d"
+  integrity sha512-VkR0iydimCiAs/4v0Ialne2ry3UZh4rjfur1kaJBUJKKTXH+jGBmLEZKlZnoKGsw6OMKLVcMdoK0N8nshY2zcg==
+
 eslint-config-salesforce@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/eslint-config-salesforce/-/eslint-config-salesforce-0.1.6.tgz#47d7846d340df99db25962978e414e03404e5c2a"
   integrity sha512-QloeQzIka5Ruj6RfkfqeNPZoaR7wkz34AU/RABVdn/XBd23lk/l0/I/Hx3Rzx0G4dft/DBaHBL1JYllT0cWE1A==
+
+eslint-config-salesforce@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-salesforce/-/eslint-config-salesforce-1.0.1.tgz#947c15d5247a28c7bb9564e9427e2fd112b97b8a"
+  integrity sha512-36iRnrB+jC//I71Cuid7BDvPotHH9XiTbA96c7HUeuniyxqFk2G0Xdwsyf54AEknqFqzdnqBIU/IDL38ozgy4Q==
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
@@ -2691,9 +2562,9 @@ estraverse@^4.1.1:
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0, estraverse@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
-  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -2760,11 +2631,6 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-extend@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -2778,16 +2644,6 @@ extract-stack@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/extract-stack/-/extract-stack-2.0.0.tgz#11367bc865bfcd9bc0db3123e5edb57786f11f9b"
   integrity sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==
-
-extsprintf@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
-
-extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -2818,7 +2674,7 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-xml-parser@^3.17.4:
   version "3.20.3"
@@ -2957,9 +2813,9 @@ flat@^5.0.2:
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^3.1.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
-  integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
+  integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
 foreground-child@^2.0.0:
   version "2.0.0"
@@ -2969,11 +2825,6 @@ foreground-child@^2.0.0:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
 
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
-
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -2981,15 +2832,6 @@ form-data@^4.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 fromentries@^1.2.0:
@@ -3032,7 +2874,7 @@ fs-extra@^6.0.1:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 fsevents@~2.3.2:
   version "2.3.2"
@@ -3057,7 +2899,7 @@ function-bind@^1.1.1:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -3118,13 +2960,6 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-getpass@^0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
-  dependencies:
-    assert-plus "^1.0.0"
-
 git-raw-commits@^2.0.0:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.10.tgz#e2255ed9563b1c9c3ea6bd05806410290297bbc1"
@@ -3160,7 +2995,7 @@ glob@7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.2.0, glob@^7.0.0, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+glob@7.2.0, glob@^7.0.0, glob@^7.1.2, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -3180,6 +3015,18 @@ glob@^6.0.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -3248,10 +3095,10 @@ globby@^11.0.1, globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-got@^11.8.2:
-  version "11.8.3"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.8.3.tgz#f496c8fdda5d729a90b4905d2b07dbd148170770"
-  integrity sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==
+got@^11.8.5:
+  version "11.8.5"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
+  integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
   dependencies:
     "@sindresorhus/is" "^4.0.0"
     "@szmarczak/http-timer" "^4.0.5"
@@ -3265,7 +3112,7 @@ got@^11.8.2:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4, graceful-fs@^4.2.8, graceful-fs@^4.2.9:
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.8, graceful-fs@^4.2.9:
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
@@ -3274,19 +3121,6 @@ growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-  integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
-
-har-validator@~5.1.3:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
-  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
-  dependencies:
-    ajv "^6.12.3"
-    har-schema "^2.0.0"
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -3394,15 +3228,6 @@ http-parser-js@>=0.5.1:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.3.tgz#01d2709c79d41698bb01d4decc5e9da4e4a033d9"
   integrity sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==
 
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
-
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
@@ -3472,7 +3297,7 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -3482,7 +3307,7 @@ indent-string@^4.0.0:
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
   dependencies:
     once "^1.3.0"
     wrappy "1"
@@ -3603,7 +3428,7 @@ is-docker@^2.0.0:
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
@@ -3703,7 +3528,7 @@ is-text-path@^1.0.1:
   dependencies:
     text-extensions "^1.0.0"
 
-is-typedarray@^1.0.0, is-typedarray@~1.0.0:
+is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -3730,11 +3555,6 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-
 is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
@@ -3755,7 +3575,7 @@ isarray@~1.0.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 isomorphic-git@1.17.0:
   version "1.17.0"
@@ -3773,11 +3593,6 @@ isomorphic-git@1.17.0:
     readable-stream "^3.4.0"
     sha.js "^2.4.9"
     simple-get "^4.0.1"
-
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.0.0-alpha.1:
   version "3.0.0"
@@ -3867,11 +3682,6 @@ js2xmlparser@^4.0.1:
   dependencies:
     xmlcreate "^2.0.4"
 
-jsbn@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
-
 jsdoc-type-pratt-parser@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.0.4.tgz#5750d2d32ffb001866537d3baaedea7cf84c7036"
@@ -3886,11 +3696,6 @@ jsdoc-type-pratt-parser@~2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.3.tgz#3910cd0120054a512a73942d644ef1eb5a9df6e9"
   integrity sha512-QPyxq62Q8veBSDtDrWmqaEPjSCeknUV9dH/OAGt3q9an8qC8UQDqitQiw1NvoMskIESpoRZ6qzt4H3rlK0xo8A==
-
-jsen@0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/jsen/-/jsen-0.6.6.tgz#0240c18cf11350ac021456f48a7eb13bd67e0420"
-  integrity sha1-AkDBjPETUKwCFFb0in6xO9Z+BCA=
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -3923,27 +3728,6 @@ jsforce@2.0.0-beta.10:
     strip-ansi "^6.0.0"
     xml2js "^0.4.22"
 
-jsforce@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-1.11.0.tgz#7e853b82c534f1fe8e18f432a344bae81881a133"
-  integrity sha512-vYNXJXXdz9ZQNdfRqq/MCJ/zU7JGA7iEduwafQDzChR9FeqXgTNfHTppLVbw9mIniKkQZemmxSOtl7N04lj/5Q==
-  dependencies:
-    base64-url "^2.2.0"
-    co-prompt "^1.0.0"
-    coffeescript "^1.10.0"
-    commander "^2.9.0"
-    csv-parse "^4.10.1"
-    csv-stringify "^1.0.4"
-    faye "^1.4.0"
-    inherits "^2.0.1"
-    lodash "^4.17.19"
-    multistream "^2.0.5"
-    opn "^5.3.0"
-    promise "^7.1.1"
-    readable-stream "^2.1.0"
-    request "^2.72.0"
-    xml2js "^0.4.16"
-
 json-buffer@3.0.1, json-buffer@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -3969,20 +3753,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
-  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
-
-json-stringify-safe@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 json5@^1.0.1:
   version "1.0.1"
@@ -4024,22 +3798,6 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonwebtoken@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz#ebd0ca2a69797816e1c5af65b6c759787252947e"
-  integrity sha512-IqEycp0znWHNA11TpYi77bVgyBO/pGESDh7Ajhas+u0ttkGkKYIIAjniL4Bw5+oVejVF+SYkaI7XKfwCCyeTuA==
-  dependencies:
-    jws "^3.2.1"
-    lodash.includes "^4.3.0"
-    lodash.isboolean "^3.0.3"
-    lodash.isinteger "^4.0.4"
-    lodash.isnumber "^3.0.3"
-    lodash.isplainobject "^4.0.6"
-    lodash.isstring "^4.0.1"
-    lodash.once "^4.0.0"
-    ms "^2.1.1"
-    semver "^5.6.0"
-
 jsonwebtoken@8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
@@ -4056,16 +3814,6 @@ jsonwebtoken@8.5.1:
     ms "^2.1.1"
     semver "^5.6.0"
 
-jsprim@^1.2.2:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
-  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
-  dependencies:
-    assert-plus "1.0.0"
-    extsprintf "1.3.0"
-    json-schema "0.2.3"
-    verror "1.10.0"
-
 just-extend@^4.0.2:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
@@ -4080,18 +3828,13 @@ jwa@^1.4.1:
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^3.2.1, jws@^3.2.2:
+jws@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
   integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
   dependencies:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
-
-keypress@~0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.2.1.tgz#1e80454250018dbad4c3fe94497d6e67b6269c77"
-  integrity sha1-HoBFQlABjbrUw/6USX1uZ7YmnHc=
 
 keyv@^4.0.0:
   version "4.2.9"
@@ -4193,7 +3936,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.get@^4, lodash.get@^4.4.2, lodash.get@~4.4.2:
+lodash.get@^4, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -4401,7 +4144,7 @@ mime-db@1.50.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.50.0.tgz#abd4ac94e98d3c0e185016c67ab45d5fde40c11f"
   integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
 
-mime-types@^2.1.12, mime-types@~2.1.19:
+mime-types@^2.1.12:
   version "2.1.33"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.33.tgz#1fa12a904472fafd068e48d9e8401f74d3f70edb"
   integrity sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==
@@ -4438,7 +4181,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-"minimatch@2 || 3", minimatch@^3.0.4:
+"minimatch@2 || 3":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -4449,6 +4192,13 @@ minimatch@4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-4.2.1.tgz#40d9d511a46bdc4e563c22c3080cde9c0d8299b4"
   integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.0.4, minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -4551,14 +4301,6 @@ multimatch@^4.0.0:
     arrify "^2.0.1"
     minimatch "^3.0.4"
 
-multistream@^2.0.5:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/multistream/-/multistream-2.1.1.tgz#629d3a29bd76623489980d04519a2c365948148c"
-  integrity sha512-xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "^2.0.5"
-
 multistream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/multistream/-/multistream-3.1.0.tgz#49c382bc0bb355e34d15ba3a9fc1cf0f66b9fded"
@@ -4599,7 +4341,7 @@ nanoid@3.3.1:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 natural-orderby@^2.0.1:
   version "2.0.3"
@@ -4753,11 +4495,6 @@ nyc@^15.1.0:
     test-exclude "^6.0.0"
     yargs "^15.0.2"
 
-oauth-sign@~0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
@@ -4820,13 +4557,6 @@ open@^7.0.0:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
-
-opn@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
-  integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
-  dependencies:
-    is-wsl "^1.1.0"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -5009,7 +4739,7 @@ path-exists@^4.0.0:
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
@@ -5042,11 +4772,6 @@ pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
-
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
@@ -5116,14 +4841,7 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
-psl@^1.1.28, psl@^1.1.33:
+psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
@@ -5164,11 +4882,6 @@ qqjs@^0.3.10:
     tar-fs "^2.0.0"
     tmp "^0.1.0"
     write-json-file "^4.1.1"
-
-qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -5220,7 +4933,7 @@ readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stre
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@~2.3.6:
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -5290,32 +5003,6 @@ release-zalgo@^1.0.0:
   integrity sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
   dependencies:
     es6-error "^4.0.1"
-
-request@^2.72.0:
-  version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
-  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -5438,7 +5125,7 @@ rxjs@^6.4.0, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@*, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@*, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -5453,7 +5140,7 @@ safe-json-stringify@~1:
   resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
   integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -5741,21 +5428,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sshpk@^1.7.0:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
-  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
-  dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    bcrypt-pbkdf "^1.0.0"
-    dashdash "^1.12.0"
-    ecc-jsbn "~0.1.1"
-    getpass "^0.1.1"
-    jsbn "~0.1.0"
-    safer-buffer "^2.0.2"
-    tweetnacl "~0.14.0"
-
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
@@ -5954,7 +5626,7 @@ text-extensions@^1.0.0:
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 through2@^4.0.0:
   version "4.0.2"
@@ -6002,14 +5674,6 @@ tough-cookie@*:
     psl "^1.1.33"
     punycode "^2.1.1"
     universalify "^0.1.2"
-
-tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -6121,11 +5785,6 @@ tunnel-agent@*, tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
-  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
-
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -6186,10 +5845,15 @@ typedoc@0.22.11:
     minimatch "^3.0.4"
     shiki "^0.10.0"
 
-typescript@^4.1.3, typescript@^4.4.3, typescript@^4.4.4:
+typescript@^4.1.3, typescript@^4.4.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
   integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"
@@ -6253,7 +5917,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -6275,15 +5939,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
-  dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
 
 vscode-oniguruma@^1.6.1:
   version "1.6.1"
@@ -6399,7 +6054,7 @@ wrap-ansi@^7.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 write-file-atomic@^3.0.0:
   version "3.0.3"
@@ -6423,7 +6078,7 @@ write-json-file@^4.1.1:
     sort-keys "^4.0.0"
     write-file-atomic "^3.0.0"
 
-xml2js@^0.4.16, xml2js@^0.4.22:
+xml2js@^0.4.22:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,6 +669,31 @@
     mkdirp "1.0.4"
     ts-retry-promise "^0.6.0"
 
+"@salesforce/core@^3.19.2":
+  version "3.19.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.19.2.tgz#45b55fec4425ec9a447aba682a0add084c8ba73a"
+  integrity sha512-uz2ehET9zz8WJj9Gicui3zxSN34TsmjgxrP22XCdQS7/GNhye1SlV8a6ayyQLqJbYlANrPFAs1RhF6LV1mPokg==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.5.41"
+    "@salesforce/schemas" "^1.1.0"
+    "@salesforce/ts-types" "^1.5.20"
+    "@types/graceful-fs" "^4.1.5"
+    "@types/mkdirp" "^1.0.2"
+    "@types/semver" "^7.3.9"
+    ajv "^8.11.0"
+    archiver "^5.3.0"
+    change-case "^4.1.2"
+    debug "^3.2.7"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    graceful-fs "^4.2.9"
+    js2xmlparser "^4.0.1"
+    jsforce "2.0.0-beta.10"
+    jsonwebtoken "8.5.1"
+    mkdirp "1.0.4"
+    ts-retry-promise "^0.6.0"
+
 "@salesforce/dev-config@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-3.0.1.tgz#631a952abfd69e7cdb0fb312ba4b1656ae632b90"

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,35 +687,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.6.0"
 
-"@salesforce/core@^3.20.1", "@salesforce/core@^3.21.1":
-  version "3.21.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.21.3.tgz#c19adb691d14c4c2c1ddcd9b63b054a7f69e4f05"
-  integrity sha512-tpGLCkkjKCsuK7gACwHjb6C0D7i9KRXMr4Na7hahHB7GxNvTWi8ZpgXcKd1nMumHpUeMZ5vmEQPuCP9MSOmeRQ==
-  dependencies:
-    "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.5.41"
-    "@salesforce/schemas" "^1.1.0"
-    "@salesforce/ts-types" "^1.5.20"
-    "@types/graceful-fs" "^4.1.5"
-    "@types/mkdirp" "^1.0.2"
-    "@types/semver" "^7.3.9"
-    ajv "^8.11.0"
-    archiver "^5.3.0"
-    change-case "^4.1.2"
-    debug "^3.2.7"
-    faye "^1.4.0"
-    form-data "^4.0.0"
-    graceful-fs "^4.2.9"
-    js2xmlparser "^4.0.1"
-    jsforce "2.0.0-beta.12"
-    jsonwebtoken "8.5.1"
-    mkdirp "1.0.4"
-    ts-retry-promise "^0.6.0"
-
-"@salesforce/core@^3.21.5":
-  version "3.21.5"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.21.5.tgz#d85aa87af8a553bbfe02f5c7574bd775384eb9d9"
-  integrity sha512-UkWccO+oQ1EDa5ao+beTI3CpaBwwKWRZsbviIXZNL3oa19uB8Lv3kiQoMUSIGQKi2iWqZ5JuYjqkPBVhjBJjbg==
+"@salesforce/core@^3.20.1", "@salesforce/core@^3.21.1", "@salesforce/core@^3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.22.1.tgz#479dc84d84b803f8e0d1b9ce4558c6d1fda1daaa"
+  integrity sha512-cPlauksBXMst0brZjiuzK7We5MB0S11/dh8T+0yYABivFjAkBYWn/90VaziD3gSrJwZsboNUKPmi9mSp5siYpA==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.41"


### PR DESCRIPTION
> requires https://github.com/forcedotcom/source-deploy-retrieve/pull/644

### What does this PR do?
support for event-based source tracking
- 2 new params when instantiating STL to opt into event-based tracking
- maybeApplyRemoteDeletesToLocal (convenience method for pulls)
- new exported SourceConflictError to standardize conflict json structure
- BREAKING: overloads for getChanges to match return types to `format` param.  Consumers must remove the <type> from the call

factor some functions out of SourceTracking.ts into their own files

### What issues does this PR fix or reference?
[@W-11186378@](https://gus.lightning.force.com/a07EE00000xc1DjYAI)