### PR TITLE
Fix the issue: Sfdx push after deleting the translation is failing for DEB

### DIFF
--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -19,7 +19,8 @@ export const getKeyFromObject = (element: RemoteChangeElement | ChangeResult): s
   throw new Error(`unable to complete key from ${JSON.stringify(element)}`);
 };
 
-export const isBundle = (cmp: SourceComponent): boolean => cmp.type.strategies?.adapter === 'bundle';
+export const isBundle = (cmp: SourceComponent): boolean => 
+cmp.type.strategies?.adapter === 'bundle' || cmp.type.strategies?.adapter === 'digitalExperience';
 export const isLwcLocalOnlyTest = (filePath: string): boolean =>
   filePath.includes('__utam__') || filePath.includes('__tests__');
 


### PR DESCRIPTION
### What does this PR do?
Modify the isBundle method to also consider "digitalExperience", as it is extending the "bundle" adapter.

### What issues does this PR fix or reference?
After deleting a translation file of a view named "TestPage" ex : "fr.json" and doing sfdx force:source:push is trying to delete the whole view "TestPage" of DEB.
This PR fixes the issue by considering the "digitalExperience" adapter also as bundle [here](https://github.com/forcedotcom/source-tracking/blob/a8efa5eaf34022c7ccac51f521895d51ec98e7f5/src/shared/localComponentSetArray.ts#L79) 