### PR TITLE
fix: empty project path when pulling remote deletes

### DIFF
--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -368,15 +368,19 @@ export class SourceTracking extends AsyncCreatable {
         true // skip polling because it's a pull
       ),
     ]);
-    return filenames.map(
-      (filename) =>
-        ({
-          state: 'Deleted',
-          filename,
-          type: sourceComponentByFileName.get(filename)?.type.name,
-          fullName: sourceComponentByFileName.get(filename)?.fullName,
-        } as unknown as FileResponse)
-    );
+    return filenames.reduce<FileResponse[]>((result, filename) => {
+      const component = sourceComponentByFileName.get(filename);
+      if (component) {
+        result.push({
+          state: ComponentStatus.Deleted,
+          filePath: filename,
+          type: component.type.name,
+          fullName: component.fullName,
+        });
+      }
+
+      return result;
+    }, []);
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `deleteFilesAndUpdateTracking` function that was returning `FileResponse`s with `filename` instead of the `filePath` key. 
It removes the typecasting to `FileResponse` making sure that the TS compiler checks the returning object type definition.

### What issues does this PR fix or reference?

Fixes displaying an empty `PROJECT PATH` when pulling deleted remote sources. 
