### PR TITLE
fix: bump isomorphic-git

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,5 @@ updates:
       prefix-development: chore(dev-deps)
     ignore:
       - dependency-name: '@salesforce/dev-scripts'
-      - dependency-name: 'isomorphic-git'
       - dependency-name: '*'
         update-types: ['version-update:semver-major']

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@salesforce/source-deploy-retrieve": "^9.2.6",
     "fast-xml-parser": "^4.2.5",
     "graceful-fs": "^4.2.11",
-    "isomorphic-git": "1.24.2",
+    "isomorphic-git": "^1.24.2",
     "ts-retry-promise": "^0.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@salesforce/source-deploy-retrieve": "^9.2.6",
     "fast-xml-parser": "^4.2.5",
     "graceful-fs": "^4.2.11",
-    "isomorphic-git": "1.23.0",
+    "isomorphic-git": "1.24.2",
     "ts-retry-promise": "^0.7.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3229,7 +3229,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-isomorphic-git@1.24.2:
+isomorphic-git@^1.24.2:
   version "1.24.2"
   resolved "https://registry.yarnpkg.com/isomorphic-git/-/isomorphic-git-1.24.2.tgz#16ee555f1cc8a812bb1337fa6d90def7f7ad03e6"
   integrity sha512-J3TU97JENWUnOgpVMwaRP9a3OQXJq/8fCIzA4yrJ7+ko1IPJwXCYeA69CeC8GtHeBVhcOQrbZGw6fpIpz54Vpw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3229,10 +3229,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-isomorphic-git@1.23.0:
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-git/-/isomorphic-git-1.23.0.tgz#3afaeb2831e57a2eb95d6ef503cf8251424f03f2"
-  integrity sha512-7mQlnZivFwrU6B3CswvmoNtVN8jqF9BcLf80uk7yh4fNA8PhFjAfQigi2Hu/Io0cmIvpOc7vn0/Rq3KtL5Ph8g==
+isomorphic-git@1.24.2:
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/isomorphic-git/-/isomorphic-git-1.24.2.tgz#16ee555f1cc8a812bb1337fa6d90def7f7ad03e6"
+  integrity sha512-J3TU97JENWUnOgpVMwaRP9a3OQXJq/8fCIzA4yrJ7+ko1IPJwXCYeA69CeC8GtHeBVhcOQrbZGw6fpIpz54Vpw==
   dependencies:
     async-lock "^1.1.0"
     clean-git-ref "^2.0.1"


### PR DESCRIPTION
### What does this PR do?
bumps isomorphic-git to latest. 
It was pinned to 1.23.0 here:
https://github.com/forcedotcom/source-tracking/pull/417

v1.24.2 is safe to use:
https://github.com/forcedotcom/cli/issues/2194#issuecomment-1611013542

### What issues does this PR fix or reference?
[skip-validate-pr]