### PR TITLE
fix: always ask at least once for sourceMembers

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@salesforce/core": "^4.3.11",
     "@salesforce/kit": "^3.0.6",
     "@salesforce/source-deploy-retrieve": "^9.4.2",
+    "@salesforce/ts-types": "^2.0.5",
     "fast-xml-parser": "^4.2.5",
     "graceful-fs": "^4.2.11",
     "isomorphic-git": "1.23.0",


### PR DESCRIPTION
### What does this PR do?
1. when there were 0 expected sourceMembers (ex: you were only deploying a COT) there would no source tracking update.

2. start capturing in telemery the sourceMember changes we didnt' expect but received anyway. This will help avoid overly broad filters AND identify places where the ARE coming, but we're not expecting the correct name.

a bit of general cleanup

### What issues does this PR fix or reference?
failures from just-nuts like https://github.com/salesforcecli/cli/actions/runs/5617978400/job/15223483795