### PR TITLE
fix: avoid duplicate STL listeners when multiple instances exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^5.2.0",
+    "@salesforce/core": "^5.3.0",
     "@salesforce/kit": "^3.0.9",
     "@salesforce/source-deploy-retrieve": "^9.7.15",
     "@salesforce/ts-types": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -46,17 +46,17 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^5.3.0",
-    "@salesforce/kit": "^3.0.9",
-    "@salesforce/source-deploy-retrieve": "^9.7.15",
-    "@salesforce/ts-types": "^2.0.6",
+    "@salesforce/core": "^5.3.1",
+    "@salesforce/kit": "^3.0.12",
+    "@salesforce/source-deploy-retrieve": "^9.7.18",
+    "@salesforce/ts-types": "^2.0.8",
     "fast-xml-parser": "^4.2.5",
     "graceful-fs": "^4.2.11",
     "isomorphic-git": "1.23.0",
     "ts-retry-promise": "^0.7.0"
   },
   "devDependencies": {
-    "@salesforce/cli-plugins-testkit": "^4.3.0",
+    "@salesforce/cli-plugins-testkit": "^4.4.2",
     "@salesforce/dev-config": "^4.0.1",
     "@salesforce/dev-scripts": "^5.10.0",
     "@salesforce/prettier-config": "^0.0.3",

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -660,35 +660,51 @@ export class SourceTracking extends AsyncCreatable {
       if (!this.ignoreConflicts) {
         this.logger.debug('subscribing to predeploy/retrieve events');
         // subscribe to SDR `pre` events to handle conflicts before deploy/retrieve
-        lifecycle.on('scopedPreDeploy', async (e: ScopedPreDeploy) => {
-          this.logger.debug('received scopedPreDeploy event');
-          if (e.orgId === this.orgId) {
-            throwIfConflicts(findConflictsInComponentSet(e.componentSet, await this.getConflicts()));
-          }
-        });
-        lifecycle.on('scopedPreRetrieve', async (e: ScopedPreRetrieve) => {
-          this.logger.debug('received scopedPreRetrieve event');
-          if (e.orgId === this.orgId) {
-            throwIfConflicts(findConflictsInComponentSet(e.componentSet, await this.getConflicts()));
-          }
-        });
+        lifecycle.on(
+          'scopedPreDeploy',
+          async (e: ScopedPreDeploy) => {
+            this.logger.debug('received scopedPreDeploy event');
+            if (e.orgId === this.orgId) {
+              throwIfConflicts(findConflictsInComponentSet(e.componentSet, await this.getConflicts()));
+            }
+          },
+          `stl#scopedPreDeploy-${this.orgId}`
+        );
+        lifecycle.on(
+          'scopedPreRetrieve',
+          async (e: ScopedPreRetrieve) => {
+            this.logger.debug('received scopedPreRetrieve event');
+            if (e.orgId === this.orgId) {
+              throwIfConflicts(findConflictsInComponentSet(e.componentSet, await this.getConflicts()));
+            }
+          },
+          `stl#scopedPreRetrieve-${this.orgId}`
+        );
       }
       // subscribe to SDR post-deploy event
       this.logger.debug('subscribing to postdeploy/retrieve events');
 
       // yes, the post hooks really have different payloads!
-      lifecycle.on('scopedPostDeploy', async (e: ScopedPostDeploy) => {
-        this.logger.debug('received scopedPostDeploy event');
-        if (e.orgId === this.orgId && e.deployResult.response.success) {
-          await this.updateTrackingFromDeploy(e.deployResult);
-        }
-      });
-      lifecycle.on('scopedPostRetrieve', async (e: ScopedPostRetrieve) => {
-        this.logger.debug('received scopedPostRetrieve event');
-        if (e.orgId === this.orgId && e.retrieveResult.response.success) {
-          await this.updateTrackingFromRetrieve(e.retrieveResult);
-        }
-      });
+      lifecycle.on(
+        'scopedPostDeploy',
+        async (e: ScopedPostDeploy) => {
+          this.logger.debug('received scopedPostDeploy event');
+          if (e.orgId === this.orgId && e.deployResult.response.success) {
+            await this.updateTrackingFromDeploy(e.deployResult);
+          }
+        },
+        `stl#scopedPostDeploy-${this.orgId}`
+      );
+      lifecycle.on(
+        'scopedPostRetrieve',
+        async (e: ScopedPostRetrieve) => {
+          this.logger.debug('received scopedPostRetrieve event');
+          if (e.orgId === this.orgId && e.retrieveResult.response.success) {
+            await this.updateTrackingFromRetrieve(e.retrieveResult);
+          }
+        },
+        `stl#scopedPostRetrieve-${this.orgId}`
+      );
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,10 +550,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.7.0"
 
-"@salesforce/core@^5.2.0", "@salesforce/core@^5.2.7", "@salesforce/core@^5.2.9":
-  version "5.2.10"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.2.10.tgz#7f4824ddcef108b6ccec24434260c620de39012e"
-  integrity sha512-Xj1QRajmHWgl0ahivjKFGKJlGXwe9yFOZ3PwF91qEupGbO74XrCJ8OUM7EVlk53LKy9LlPZQFuy2ATX9MyEDKA==
+"@salesforce/core@^5.2.0", "@salesforce/core@^5.2.7", "@salesforce/core@^5.2.9", "@salesforce/core@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.3.0.tgz#2cf9e2ed7c32c59ae04af185d6906d681adffc4e"
+  integrity sha512-8Jlvv9CfkKc53o2uFsWDHqIKjn1nhlzHvxAN96cmph2jq2480kb24U8ouGm6FRGeBiBodYUN5cFJKnOpAXMrig==
   dependencies:
     "@salesforce/kit" "^3.0.11"
     "@salesforce/schemas" "^1.6.0"
@@ -904,12 +904,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/semver@^7.3.12":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
-  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
-
-"@types/semver@^7.5.2":
+"@types/semver@^7.3.12", "@types/semver@^7.5.2":
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.2.tgz#31f6eec1ed7ec23f4f05608d3a2d381df041f564"
   integrity sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==
@@ -4459,15 +4454,7 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pino-abstract-transport@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz#cc0d6955fffcadb91b7b49ef220a6cc111d48bb3"
-  integrity sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==
-  dependencies:
-    readable-stream "^4.0.0"
-    split2 "^4.0.0"
-
-pino-abstract-transport@v1.1.0:
+pino-abstract-transport@^1.0.0, pino-abstract-transport@v1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz#083d98f966262164504afb989bccd05f665937a8"
   integrity sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==
@@ -5431,12 +5418,7 @@ ts-prune@^0.10.3:
     "true-myth" "^4.1.0"
     ts-morph "^13.0.1"
 
-ts-retry-promise@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/ts-retry-promise/-/ts-retry-promise-0.7.0.tgz#08f2dcbbf5d2981495841cb63389a268324e8147"
-  integrity sha512-x6yWZXC4BfXy4UyMweOFvbS1yJ/Y5biSz/mEPiILtJZLrqD3ZxIpzVOGGgifHHdaSe3WxzFRtsRbychI6zofOg==
-
-ts-retry-promise@^0.7.1:
+ts-retry-promise@^0.7.0, ts-retry-promise@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ts-retry-promise/-/ts-retry-promise-0.7.1.tgz#176d6eee6415f07b6c7c286d3657355e284a6906"
   integrity sha512-NhHOCZ2AQORvH42hOPO5UZxShlcuiRtm7P2jIq2L2RY3PBxw2mLnUsEdHrIslVBFya1v5aZmrR55lWkzo13LrQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,25 +535,25 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@salesforce/cli-plugins-testkit@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.3.0.tgz#253079d476569fbc4977c8100b3bf201b3e4a788"
-  integrity sha512-kW59i4muO49evQ76waWTfDUXpTfyBUQ0N1QIF4ZFB+aSAdVGG5N/oTMYz882ScS/SwB0XP0H119wT4cLoJI+Mw==
+"@salesforce/cli-plugins-testkit@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.4.2.tgz#5b3a70906a032698303c220d768dec3608cfff9d"
+  integrity sha512-1KRhBKAT+3aAChlhvFenmfgsrhphpA9bzvg/J/gAB3O113iwLCuH5ipzo1SU+fR3wWogIPubOWX0U7JNoHDkIw==
   dependencies:
-    "@salesforce/core" "^5.2.0"
-    "@salesforce/kit" "^3.0.9"
+    "@salesforce/core" "^5.2.10"
+    "@salesforce/kit" "^3.0.11"
     "@salesforce/ts-types" "^2.0.6"
     "@types/shelljs" "^0.8.12"
     debug "^4.3.1"
     jszip "^3.10.1"
     shelljs "^0.8.4"
     strip-ansi "6.0.1"
-    ts-retry-promise "^0.7.0"
+    ts-retry-promise "^0.7.1"
 
-"@salesforce/core@^5.2.0", "@salesforce/core@^5.2.7", "@salesforce/core@^5.2.9", "@salesforce/core@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.3.0.tgz#2cf9e2ed7c32c59ae04af185d6906d681adffc4e"
-  integrity sha512-8Jlvv9CfkKc53o2uFsWDHqIKjn1nhlzHvxAN96cmph2jq2480kb24U8ouGm6FRGeBiBodYUN5cFJKnOpAXMrig==
+"@salesforce/core@^5.2.10", "@salesforce/core@^5.2.7", "@salesforce/core@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.3.1.tgz#93c49760faa7b503bbfea8376d80a66815065e4a"
+  integrity sha512-LEQ3Yp7GxexsGXxT85Pp4AgOzzqY9Y3kol8ByVsHpHGvs8XLRbKl44IPxTXBdMB2roFM+Iosd46i0KbTuh2MQg==
   dependencies:
     "@salesforce/kit" "^3.0.11"
     "@salesforce/schemas" "^1.6.0"
@@ -618,10 +618,10 @@
     typescript "^4.9.5"
     wireit "^0.9.5"
 
-"@salesforce/kit@^3.0.11", "@salesforce/kit@^3.0.9":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.0.11.tgz#d03160b658da9817c05e62479ca18283087a0fc0"
-  integrity sha512-ar44uFJfc/RCDWjz7LlrOtFCFHgNNUpddxe0eJCLqQuR/Xs3IlLZKuovWTx322Rzu+V9IIKrIdpz2IqA95/ClA==
+"@salesforce/kit@^3.0.11", "@salesforce/kit@^3.0.12":
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.0.12.tgz#8d598813fd3dce9545951186cfa579bafaac374a"
+  integrity sha512-+2bjUaIbS1/XrYBYxpS5zKyQER8dgVakIL6X/MxZVZFJaLHithkLXvrUKYd5tZEaijxBZq1ooIkGm2yCLrg8Ew==
   dependencies:
     "@salesforce/ts-types" "^2.0.7"
     tslib "^2.6.2"
@@ -636,12 +636,12 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.0.tgz#14505ebad2fb2d4f7b14837545d662766d293561"
   integrity sha512-SwhDTLucj/GRbPpxlEoDZeqlX22o+G6fiebTXTu1cZKmd1oE0W2L7SlTTgJnWck8bhTeBIgQi9cpD8c2t5ISKA==
 
-"@salesforce/source-deploy-retrieve@^9.7.15":
-  version "9.7.15"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-9.7.15.tgz#a891e95101816a7e33854bc42ba21fafbdb1728e"
-  integrity sha512-av9Ojd9B/uegLNJth41aVPvAVPh8N0CllzfiDG5qbtDXW7WV/bqgWjiiiGc1U6RWnJ9OmQZNL/EjaSX0UPhiLA==
+"@salesforce/source-deploy-retrieve@^9.7.18":
+  version "9.7.18"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-9.7.18.tgz#38b1577eec7ae08c3ed627c7a38f59c87632b01d"
+  integrity sha512-kdnX8P/cjUwgKnDF60kXlvm4zwP2xXpFqEB3KniSrvuvbzXKrPbaa05cJvHVnTohAcYTNPHiM+LNkTgZuENNmA==
   dependencies:
-    "@salesforce/core" "^5.2.9"
+    "@salesforce/core" "^5.2.10"
     "@salesforce/kit" "^3.0.11"
     "@salesforce/ts-types" "^2.0.7"
     fast-levenshtein "^3.0.0"
@@ -664,10 +664,10 @@
     sinon "^5.1.1"
     tslib "^2.6.1"
 
-"@salesforce/ts-types@^2.0.6", "@salesforce/ts-types@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.7.tgz#02a6999d0b0e7bcd6c6d8ce621c79fa61af24701"
-  integrity sha512-8csXgstPuy6QXL3JavkIi/f8DOWHBNCvWeszrFu5sbVlcKO3YqOOCE+rDFGPkrZsYv5OywV6H8kEi877bWOz6Q==
+"@salesforce/ts-types@^2.0.6", "@salesforce/ts-types@^2.0.7", "@salesforce/ts-types@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.8.tgz#e732b5a42cbec6bda79c089a0633fc643daf8bca"
+  integrity sha512-vuzLcxtThBhpuhmnoh8GFrVU8XjdoNyQm9gPtmcjUyUD/9nQIBTAX8oGoUvCiiq93c4LFEmSua+xm3yu0bbNfg==
   dependencies:
     tslib "^2.6.2"
 


### PR DESCRIPTION
### What does this PR do?
prevent STL from registering multiple listeners.  Helps where VSCode leaves long-running multiple STL instances around and listeners aren't getting cleaned up.

### What issues does this PR fix or reference?
@W-14157566@
https://github.com/forcedotcom/cli/issues/2441
https://github.com/forcedotcom/cli/issues/2458
https://github.com/forcedotcom/cli/issues/2483
https://github.com/forcedotcom/cli/issues/2476
and, I think, https://github.com/forcedotcom/cli/issues/2439