### PR TITLE
fix: bump to SDR 9.7.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@salesforce/core": "^5.3.9",
     "@salesforce/kit": "^3.0.13",
-    "@salesforce/source-deploy-retrieve": "^9.7.24",
+    "@salesforce/source-deploy-retrieve": "^9.7.25",
     "@salesforce/ts-types": "^2.0.8",
     "fast-xml-parser": "^4.2.5",
     "graceful-fs": "^4.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,10 +636,10 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.0.tgz#14505ebad2fb2d4f7b14837545d662766d293561"
   integrity sha512-SwhDTLucj/GRbPpxlEoDZeqlX22o+G6fiebTXTu1cZKmd1oE0W2L7SlTTgJnWck8bhTeBIgQi9cpD8c2t5ISKA==
 
-"@salesforce/source-deploy-retrieve@^9.7.24":
-  version "9.7.24"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-9.7.24.tgz#6a200b830311b0db08a86026ece98c734d56f8c2"
-  integrity sha512-nkP9KgzuCoV6LtdDxgxt7KRnoQ6ZS12DJgXErCBXm7Swmr0dnbo1LhxrH05C4UFFe0JuvSta+u+Oor8jxSGaCQ==
+"@salesforce/source-deploy-retrieve@^9.7.25":
+  version "9.7.25"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-9.7.25.tgz#30f1eda5bf450deab57e6840b3a8a4543de08dba"
+  integrity sha512-X2J6hYEyMALtAkIA8pTfLUfZ7n9NdCzGitSakuD771RmOk92GRcdht143TMhvpgZ5J5rRNXsbvGRX2c+E8IANg==
   dependencies:
     "@salesforce/core" "^5.3.1"
     "@salesforce/kit" "^3.0.11"


### PR DESCRIPTION
### What does this PR do?
bumps SDR dependency to at least 9.7.25

[skip-validate-pr]
