### PR TITLE
custom registry support

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@oclif/core": "^3.25.2",
-    "@salesforce/core": "^6.7.1",
+    "@salesforce/core": "^6.7.3",
     "@salesforce/kit": "^3.0.15",
     "@salesforce/source-deploy-retrieve": "^10.5.2",
     "@salesforce/ts-types": "^2.0.9",

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@oclif/core": "^3.25.2",
+    "@oclif/core": "^3.26.0",
     "@salesforce/core": "^6.7.3",
     "@salesforce/kit": "^3.1.0",
-    "@salesforce/source-deploy-retrieve": "^10.5.2",
+    "@salesforce/source-deploy-retrieve": "^10.6.0",
     "@salesforce/ts-types": "^2.0.9",
     "fast-xml-parser": "^4.2.5",
     "graceful-fs": "^4.2.11",
@@ -55,13 +55,13 @@
     "ts-retry-promise": "^0.8.0"
   },
   "devDependencies": {
-    "@salesforce/cli-plugins-testkit": "^5.1.10",
+    "@salesforce/cli-plugins-testkit": "^5.1.12",
     "@salesforce/dev-scripts": "^8.4.2",
     "@types/graceful-fs": "^4.1.9",
     "eslint-plugin-sf-plugin": "^1.17.4",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.1.2",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "config": {},
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@oclif/core": "^3.25.2",
     "@salesforce/core": "^6.7.3",
-    "@salesforce/kit": "^3.0.15",
+    "@salesforce/kit": "^3.1.0",
     "@salesforce/source-deploy-retrieve": "^10.5.2",
     "@salesforce/ts-types": "^2.0.9",
     "fast-xml-parser": "^4.2.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@oclif/core": "^3.26.0",
     "@salesforce/core": "^6.7.3",
     "@salesforce/kit": "^3.1.0",
-    "@salesforce/source-deploy-retrieve": "^10.6.0",
+    "@salesforce/source-deploy-retrieve": "^10.6.1",
     "@salesforce/ts-types": "^2.0.9",
     "fast-xml-parser": "^4.2.5",
     "graceful-fs": "^4.2.11",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export * from './sourceTracking';
+export { SourceTracking, SourceTrackingOptions } from './sourceTracking';
 export {
   RemoteSyncInput,
   ChangeOptionType,

--- a/src/shared/conflicts.ts
+++ b/src/shared/conflicts.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { resolve } from 'node:path';
-import { ComponentSet, ForceIgnore } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet, ForceIgnore, RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import { ConflictResponse, ChangeResult, SourceConflictError } from './types';
 import { getMetadataKey } from './functions';
 import { populateTypesAndNames } from './populateTypesAndNames';
@@ -48,11 +48,13 @@ export const getDedupedConflictsFromChanges = ({
   remoteChanges = [],
   projectPath,
   forceIgnore,
+  registry,
 }: {
   localChanges: ChangeResult[];
   remoteChanges: ChangeResult[];
   projectPath: string;
   forceIgnore: ForceIgnore;
+  registry: RegistryAccess;
 }): ChangeResult[] => {
   const metadataKeyIndex = new Map(
     remoteChanges
@@ -65,7 +67,7 @@ export const getDedupedConflictsFromChanges = ({
 
   const conflicts = new Set<ChangeResult>();
 
-  populateTypesAndNames({ elements: localChanges, excludeUnresolvable: true, projectPath, forceIgnore })
+  populateTypesAndNames({ excludeUnresolvable: true, projectPath, forceIgnore, registry })(localChanges)
     .filter(isChangeResultWithNameAndType)
     .map((change) => {
       const metadataKey = getMetadataKey(change.name, change.type);

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -128,7 +128,7 @@ export const forceIgnoreDenies =
   (filePath: string): boolean =>
     forceIgnore?.denies(filePath) ?? false;
 
-export const sourceComponentIsCustomLabel = (input: SourceComponent): boolean => input.type.id === 'customlabel';
+export const sourceComponentIsCustomLabel = (input: SourceComponent): boolean => input.type.name === 'CustomLabel';
 
 export const sourceComponentHasFullNameAndType = (input: SourceComponent): boolean =>
   typeof input.fullName === 'string' && typeof input.type.name === 'string';

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -134,6 +134,7 @@ export const sourceComponentHasFullNameAndType = (input: SourceComponent): boole
   typeof input.fullName === 'string' && typeof input.type.name === 'string';
 
 export const getAllFiles = (sc: SourceComponent): string[] => [sc.xml, ...sc.walkContent()].filter(isString);
+
 export const remoteChangeToMetadataMember = (cr: ChangeResult): MetadataMember => {
   const checked = ensureNameAndType(cr);
 
@@ -142,6 +143,7 @@ export const remoteChangeToMetadataMember = (cr: ChangeResult): MetadataMember =
     type: checked.type,
   };
 };
+
 export const changeResultToMetadataComponent =
   (registry: RegistryAccess = new RegistryAccess()) =>
   (cr: ChangeResultWithNameAndType): MetadataComponent => ({

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -9,6 +9,7 @@ import { sep, normalize, isAbsolute, relative } from 'node:path';
 import * as fs from 'node:fs';
 import { isString } from '@salesforce/ts-types';
 import {
+  FileResponseSuccess,
   ForceIgnore,
   MetadataComponent,
   MetadataMember,
@@ -17,7 +18,7 @@ import {
 } from '@salesforce/source-deploy-retrieve';
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import { ensureArray } from '@salesforce/kit';
-import { RemoteChangeElement, ChangeResult, ChangeResultWithNameAndType } from './types';
+import { RemoteChangeElement, ChangeResult, ChangeResultWithNameAndType, RemoteSyncInput } from './types';
 import { ensureNameAndType } from './remoteChangeIgnoring';
 
 export const getMetadataKey = (metadataType: string, metadataName: string): string =>
@@ -143,6 +144,9 @@ export const remoteChangeToMetadataMember = (cr: ChangeResult): MetadataMember =
     type: checked.type,
   };
 };
+
+// weird, right?  This is for oclif.table which allows types but not interfaces.  In this case, they are equivalent
+export const FileResponseSuccessToRemoteSyncInput = (fr: FileResponseSuccess): RemoteSyncInput => fr;
 
 export const changeResultToMetadataComponent =
   (registry: RegistryAccess = new RegistryAccess()) =>

--- a/src/shared/guards.ts
+++ b/src/shared/guards.ts
@@ -40,5 +40,5 @@ export const FileResponseHasPath = (
 ): fileResponse is FileResponseSuccess & Required<Pick<FileResponseSuccess, 'filePath'>> =>
   fileResponse.filePath !== undefined;
 
-export const isChangeResultWithNameAndType = (cr: ChangeResult): cr is ChangeResultWithNameAndType =>
-  typeof cr.name === 'string' && typeof cr.type === 'string';
+export const isChangeResultWithNameAndType = (cr?: ChangeResult): cr is ChangeResultWithNameAndType =>
+  typeof cr === 'object' && typeof cr.name === 'string' && typeof cr.type === 'string';

--- a/src/shared/guards.ts
+++ b/src/shared/guards.ts
@@ -4,7 +4,16 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SourceComponent, MetadataMember } from '@salesforce/source-deploy-retrieve';
+import {
+  SourceComponent,
+  MetadataMember,
+  FileResponse,
+  ComponentStatus,
+  FileResponseFailure,
+  FileResponseSuccess,
+} from '@salesforce/source-deploy-retrieve';
+import { ChangeResult } from './types';
+import { ChangeResultWithNameAndType } from './types';
 
 export const sourceComponentGuard = (input: SourceComponent | undefined): input is SourceComponent =>
   input instanceof SourceComponent;
@@ -13,3 +22,23 @@ export const metadataMemberGuard = (
   input: MetadataMember | undefined | Partial<MetadataMember>
 ): input is MetadataMember =>
   input !== undefined && typeof input.fullName === 'string' && typeof input.type === 'string';
+
+export const isSdrFailure = (fileResponse: FileResponse): fileResponse is FileResponseFailure =>
+  fileResponse.state === ComponentStatus.Failed;
+
+export const isSdrSuccess = (fileResponse: FileResponse): fileResponse is FileResponseSuccess =>
+  fileResponse.state !== ComponentStatus.Failed;
+
+export const FileResponseIsDeleted = (fileResponse: FileResponse): boolean =>
+  fileResponse.state === ComponentStatus.Deleted;
+
+export const FileResponseIsNotDeleted = (fileResponse: FileResponse): boolean =>
+  fileResponse.state !== ComponentStatus.Deleted;
+
+export const FileResponseHasPath = (
+  fileResponse: FileResponseSuccess
+): fileResponse is FileResponseSuccess & Required<Pick<FileResponseSuccess, 'filePath'>> =>
+  fileResponse.filePath !== undefined;
+
+export const isChangeResultWithNameAndType = (cr: ChangeResult): cr is ChangeResultWithNameAndType =>
+  typeof cr.name === 'string' && typeof cr.type === 'string';

--- a/src/shared/localComponentSetArray.ts
+++ b/src/shared/localComponentSetArray.ts
@@ -12,6 +12,7 @@ import {
   MetadataResolver,
   VirtualTreeContainer,
   DestructiveChangesType,
+  RegistryAccess,
 } from '@salesforce/source-deploy-retrieve';
 import { sourceComponentGuard } from './guards';
 import { supportsPartialDelete, pathIsInFolder } from './functions';
@@ -51,11 +52,19 @@ const getNonSequential = ({
   },
 ];
 
-export const getComponentSets = (groupings: GroupedFile[], sourceApiVersion?: string): ComponentSet[] => {
+export const getComponentSets = ({
+  groupings,
+  sourceApiVersion,
+  registry = new RegistryAccess(),
+}: {
+  groupings: GroupedFile[];
+  sourceApiVersion?: string;
+  registry: RegistryAccess;
+}): ComponentSet[] => {
   const logger = Logger.childFromRoot('localComponentSetArray');
 
   // optimistic resolution...some files may not be possible to resolve
-  const resolverForNonDeletes = new MetadataResolver();
+  const resolverForNonDeletes = new MetadataResolver(registry);
 
   return groupings
     .map((grouping) => {
@@ -63,14 +72,14 @@ export const getComponentSets = (groupings: GroupedFile[], sourceApiVersion?: st
         `building componentSet for ${grouping.path} (deletes: ${grouping.deletes.length} nonDeletes: ${grouping.nonDeletes.length})`
       );
 
-      const componentSet = new ComponentSet();
+      const componentSet = new ComponentSet(undefined, registry);
       if (sourceApiVersion) {
         componentSet.sourceApiVersion = sourceApiVersion;
       }
 
       // we need virtual components for the deletes.
       // TODO: could we use the same for the non-deletes?
-      const resolverForDeletes = new MetadataResolver(undefined, VirtualTreeContainer.fromFilePaths(grouping.deletes));
+      const resolverForDeletes = new MetadataResolver(registry, VirtualTreeContainer.fromFilePaths(grouping.deletes));
 
       grouping.deletes
         .flatMap((filename) => resolverForDeletes.getComponentsFromPath(filename))

--- a/src/shared/localComponentSetArray.ts
+++ b/src/shared/localComponentSetArray.ts
@@ -35,8 +35,8 @@ export const getGroupedFiles = (input: GroupedFileInput, byPackageDir = false): 
 const getSequential = ({ packageDirs, nonDeletes, deletes }: GroupedFileInput): GroupedFile[] =>
   packageDirs.map((pkgDir) => ({
     path: pkgDir.name,
-    nonDeletes: nonDeletes.filter((f) => pathIsInFolder(f, pkgDir.name)),
-    deletes: deletes.filter((f) => pathIsInFolder(f, pkgDir.name)),
+    nonDeletes: nonDeletes.filter(pathIsInFolder(pkgDir.name)),
+    deletes: deletes.filter(pathIsInFolder(pkgDir.name)),
   }));
 
 const getNonSequential = ({

--- a/src/shared/localShadowRepo.ts
+++ b/src/shared/localShadowRepo.ts
@@ -12,7 +12,7 @@ import { NamedPackageDir, Logger, SfError } from '@salesforce/core';
 import { env } from '@salesforce/kit';
 import * as git from 'isomorphic-git';
 import { Performance } from '@oclif/core';
-import { chunkArray, isLwcLocalOnlyTest, pathIsInFolder } from './functions';
+import { chunkArray, excludeLwcLocalOnlyTest, folderContainsPath } from './functions';
 
 /** returns the full path to where we store the shadow repo */
 const getGitDir = (orgId: string, projectPath: string): string =>
@@ -23,7 +23,7 @@ const toFilenames = (rows: StatusRow[]): string[] => rows.map((row) => row[FILE]
 
 // catch isogit's `InternalError` to avoid people report CLI issues in isogit repo.
 // See: https://github.com/forcedotcom/cli/issues/2416
-const redirectToCliRepoError = (e: Error): never => {
+const redirectToCliRepoError = (e: unknown): never => {
   if (e instanceof git.Errors.InternalError) {
     const error = new SfError(
       `An internal error caused this command to fail. isomorphic-git error:${os.EOL}${e.data.message}`,
@@ -77,7 +77,7 @@ export class ShadowRepo {
 
     this.maxFileAdd = env.getNumber(
       'SF_SOURCE_TRACKING_BATCH_SIZE',
-      env.getNumber('SFDX_SOURCE_TRACKING_BATCH_SIZE', this.isWindows ? 8000 : 15000)
+      env.getNumber('SFDX_SOURCE_TRACKING_BATCH_SIZE', this.isWindows ? 8000 : 15_000)
     );
   }
 
@@ -111,7 +111,7 @@ export class ShadowRepo {
     try {
       await git.init({ fs, dir: this.projectPath, gitdir: this.gitDir, defaultBranch: 'main' });
     } catch (e) {
-      redirectToCliRepoError(e as Error);
+      redirectToCliRepoError(e);
     }
   }
 
@@ -144,9 +144,7 @@ export class ShadowRepo {
       // iso-git uses relative, posix paths
       // but packageDirs has already resolved / normalized them
       // so we need to make them project-relative again and convert if windows
-      const filepaths = this.packageDirs
-        .map((dir) => path.relative(this.projectPath, dir.fullPath))
-        .map((p) => (this.isWindows ? p.split(path.sep).join(path.posix.sep) : p));
+      const filepaths = this.packageDirs.map(packageDirToRelativePath(this.isWindows)(this.projectPath));
 
       try {
         // status hasn't been initialized yet
@@ -160,14 +158,14 @@ export class ShadowRepo {
             // no hidden files
             !f.includes(`${path.sep}.`) &&
             // no lwc tests
-            !isLwcLocalOnlyTest(f) &&
+            excludeLwcLocalOnlyTest(f) &&
             // no gitignore files
             !f.endsWith('.gitignore') &&
             // isogit uses `startsWith` for filepaths so it's possible to get a false positive
-            filepaths.some((pkgDir) => pathIsInFolder(f, pkgDir)),
+            filepaths.some(folderContainsPath),
         });
       } catch (e) {
-        redirectToCliRepoError(e as Error);
+        redirectToCliRepoError(e);
       }
       // isomorphic-git stores things in unix-style tree.  Convert to windows-style if necessary
       if (this.isWindows) {
@@ -259,10 +257,10 @@ export class ShadowRepo {
       deletedFiles: deletedFiles.length,
     });
     // these are stored in posix/style/path format.  We have to convert inbound stuff from windows
-    if (os.type() === 'Windows_NT') {
+    if (this.isWindows) {
       this.logger.trace('start: transforming windows paths to posix');
-      deployedFiles = deployedFiles.map((filepath) => path.normalize(filepath).split(path.sep).join(path.posix.sep));
-      deletedFiles = deletedFiles.map((filepath) => path.normalize(filepath).split(path.sep).join(path.posix.sep));
+      deployedFiles = deployedFiles.map(normalize).map(ensurePosix);
+      deletedFiles = deletedFiles.map(normalize).map(ensurePosix);
       this.logger.trace('done: transforming windows paths to posix');
     }
 
@@ -294,7 +292,7 @@ export class ShadowRepo {
             error.setData(e.errors);
             throw error;
           }
-          redirectToCliRepoError(e as Error);
+          redirectToCliRepoError(e);
         }
       }
     }
@@ -305,7 +303,7 @@ export class ShadowRepo {
         // eslint-disable-next-line no-await-in-loop
         await git.remove({ fs, dir: this.projectPath, gitdir: this.gitDir, filepath });
       } catch (e) {
-        redirectToCliRepoError(e as Error);
+        redirectToCliRepoError(e);
       }
     }
 
@@ -326,8 +324,19 @@ export class ShadowRepo {
       this.logger.trace('done: commitChanges git.commit');
       return sha;
     } catch (e) {
-      redirectToCliRepoError(e as Error);
+      redirectToCliRepoError(e);
     }
     marker?.stop();
   }
 }
+
+const packageDirToRelativePath =
+  (isWindows: boolean) =>
+  (projectPath: string) =>
+  (packageDir: NamedPackageDir): string =>
+    isWindows
+      ? ensurePosix(path.relative(projectPath, packageDir.fullPath))
+      : path.relative(projectPath, packageDir.fullPath);
+
+const normalize = (filepath: string): string => path.normalize(filepath);
+const ensurePosix = (filepath: string): string => filepath.split(path.sep).join(path.posix.sep);

--- a/src/shared/localShadowRepo.ts
+++ b/src/shared/localShadowRepo.ts
@@ -144,7 +144,7 @@ export class ShadowRepo {
       // iso-git uses relative, posix paths
       // but packageDirs has already resolved / normalized them
       // so we need to make them project-relative again and convert if windows
-      const filepaths = this.packageDirs.map(packageDirToRelativePath(this.isWindows)(this.projectPath));
+      const filepaths = this.packageDirs.map(packageDirToRelativePosixPath(this.isWindows)(this.projectPath));
 
       try {
         // status hasn't been initialized yet
@@ -330,7 +330,7 @@ export class ShadowRepo {
   }
 }
 
-const packageDirToRelativePath =
+const packageDirToRelativePosixPath =
   (isWindows: boolean) =>
   (projectPath: string) =>
   (packageDir: NamedPackageDir): string =>

--- a/src/shared/localShadowRepo.ts
+++ b/src/shared/localShadowRepo.ts
@@ -144,7 +144,7 @@ export class ShadowRepo {
       // iso-git uses relative, posix paths
       // but packageDirs has already resolved / normalized them
       // so we need to make them project-relative again and convert if windows
-      const filepaths = this.packageDirs.map(packageDirToRelativePosixPath(this.isWindows)(this.projectPath));
+      const pkgDirs = this.packageDirs.map(packageDirToRelativePosixPath(this.isWindows)(this.projectPath));
 
       try {
         // status hasn't been initialized yet
@@ -152,7 +152,7 @@ export class ShadowRepo {
           fs,
           dir: this.projectPath,
           gitdir: this.gitDir,
-          filepaths,
+          filepaths: pkgDirs,
           ignored: true,
           filter: (f) =>
             // no hidden files
@@ -162,7 +162,7 @@ export class ShadowRepo {
             // no gitignore files
             !f.endsWith('.gitignore') &&
             // isogit uses `startsWith` for filepaths so it's possible to get a false positive
-            filepaths.some(folderContainsPath),
+            pkgDirs.some(folderContainsPath(f)),
         });
       } catch (e) {
         redirectToCliRepoError(e);

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -25,7 +25,8 @@ const registry = new RegistryAccess();
 // only compute once
 const aliasTypes: Array<[string, string]> = registry
   .getAliasTypes()
-  .map((aliasType) => [aliasType.name, registry.getTypeByName(aliasType.aliasFor as string).name]);
+  // allow assertion because
+  .map((aliasType) => [aliasType.name, registry.getTypeByName(aliasType.aliasFor!).name]);
 
 const reverseAliasTypes = new Map(aliasTypes.map(([alias, type]) => [type, alias]));
 

--- a/src/shared/metadataKeys.ts
+++ b/src/shared/metadataKeys.ts
@@ -25,7 +25,7 @@ const registry = new RegistryAccess();
 // only compute once
 const aliasTypes: Array<[string, string]> = registry
   .getAliasTypes()
-  // allow assertion because
+  // allow assertion because aliasTypes are defined as having that property
   .map((aliasType) => [aliasType.name, registry.getTypeByName(aliasType.aliasFor!).name]);
 
 const reverseAliasTypes = new Map(aliasTypes.map(([alias, type]) => [type, alias]));

--- a/src/shared/populateFilePaths.ts
+++ b/src/shared/populateFilePaths.ts
@@ -6,7 +6,7 @@
  */
 import { EOL } from 'node:os';
 import { Logger } from '@salesforce/core';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet, RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import { ChangeResult } from './types';
 import { isChangeResultWithNameAndType } from './guards';
 import {
@@ -24,7 +24,15 @@ import {
  * @param packageDirPaths Array of paths from PackageDirectories
  * @returns
  */
-export const populateFilePaths = (elements: ChangeResult[], packageDirPaths: string[]): ChangeResult[] => {
+export const populateFilePaths = ({
+  elements,
+  packageDirPaths,
+  registry,
+}: {
+  elements: ChangeResult[];
+  packageDirPaths: string[];
+  registry: RegistryAccess;
+}): ChangeResult[] => {
   if (elements.length === 0) {
     return [];
   }
@@ -36,7 +44,7 @@ export const populateFilePaths = (elements: ChangeResult[], packageDirPaths: str
     .filter(isChangeResultWithNameAndType)
     .map(remoteChangeToMetadataMember);
 
-  const remoteChangesAsComponentSet = new ComponentSet(remoteChangesAsMetadataMember);
+  const remoteChangesAsComponentSet = new ComponentSet(remoteChangesAsMetadataMember, registry);
 
   logger.debug(` the generated component set has ${remoteChangesAsComponentSet.size.toString()} items`);
   if (remoteChangesAsComponentSet.size < elements.length) {

--- a/src/shared/populateFilePaths.ts
+++ b/src/shared/populateFilePaths.ts
@@ -67,6 +67,7 @@ export const populateFilePaths = ({
   const matchingLocalSourceComponentsSet = ComponentSet.fromSource({
     fsPaths: packageDirPaths,
     include: remoteChangesAsComponentSet,
+    registry,
   });
   logger.debug(
     ` local source-backed component set has ${matchingLocalSourceComponentsSet.size.toString()} items from remote`

--- a/src/shared/populateTypesAndNames.ts
+++ b/src/shared/populateTypesAndNames.ts
@@ -6,7 +6,12 @@
  */
 import { Logger } from '@salesforce/core';
 import { isString } from '@salesforce/ts-types';
-import { MetadataResolver, VirtualTreeContainer, ForceIgnore } from '@salesforce/source-deploy-retrieve';
+import {
+  MetadataResolver,
+  VirtualTreeContainer,
+  ForceIgnore,
+  RegistryAccess,
+} from '@salesforce/source-deploy-retrieve';
 import { ChangeResult } from './types';
 import { isChangeResultWithNameAndType, sourceComponentGuard } from './guards';
 import {
@@ -26,67 +31,71 @@ import {
  * @input excludeUnresolvable: boolean Filter out components where you can't get the name and type (that is, it's probably not a valid source component)
  * @input resolveDeleted: constructs a virtualTree instead of the actual filesystem--useful when the files no longer exist
  */
-export const populateTypesAndNames = ({
-  elements,
-  projectPath,
-  forceIgnore,
-  excludeUnresolvable = false,
-  resolveDeleted = false,
-}: {
-  elements: ChangeResult[];
-  projectPath: string;
-  forceIgnore?: ForceIgnore;
-  excludeUnresolvable?: boolean;
-  resolveDeleted?: boolean;
-}): ChangeResult[] => {
-  if (elements.length === 0) {
-    return [];
-  }
-  const logger = Logger.childFromRoot('SourceTracking.PopulateTypesAndNames');
-  logger.debug(`populateTypesAndNames for ${elements.length} change elements`);
-  const filenames = elements.flatMap((element) => element.filenames).filter(isString);
+export const populateTypesAndNames =
+  ({
+    projectPath,
+    forceIgnore,
+    excludeUnresolvable = false,
+    resolveDeleted = false,
+    registry,
+  }: {
+    projectPath: string;
+    forceIgnore?: ForceIgnore;
+    excludeUnresolvable?: boolean;
+    resolveDeleted?: boolean;
+    registry: RegistryAccess;
+  }) =>
+  (elements: ChangeResult[]): ChangeResult[] => {
+    if (elements.length === 0) {
+      return [];
+    }
+    const logger = Logger.childFromRoot('SourceTracking.PopulateTypesAndNames');
+    logger.debug(`populateTypesAndNames for ${elements.length} change elements`);
+    const filenames = elements.flatMap((element) => element.filenames).filter(isString);
 
-  // component set generated from the filenames on all local changes
-  const resolver = new MetadataResolver(
-    undefined,
-    resolveDeleted ? VirtualTreeContainer.fromFilePaths(filenames) : undefined,
-    !!forceIgnore
-  );
-  const sourceComponents = filenames
-    .flatMap((filename) => {
-      try {
-        return resolver.getComponentsFromPath(filename);
-      } catch (e) {
-        logger.warn(`unable to resolve ${filename}`);
-        return undefined;
-      }
-    })
-    .filter(sourceComponentGuard);
+    // component set generated from the filenames on all local changes
+    const resolver = new MetadataResolver(
+      registry,
+      resolveDeleted ? VirtualTreeContainer.fromFilePaths(filenames) : undefined,
+      !!forceIgnore
+    );
+    const sourceComponents = filenames
+      .flatMap((filename) => {
+        try {
+          return resolver.getComponentsFromPath(filename);
+        } catch (e) {
+          logger.warn(`unable to resolve ${filename}`);
+          return undefined;
+        }
+      })
+      .filter(sourceComponentGuard);
 
-  logger.debug(` matching SourceComponents have ${sourceComponents.length} items from local`);
+    logger.debug(` matching SourceComponents have ${sourceComponents.length} items from local`);
 
-  const elementMap = new Map(
-    elements.flatMap((e) => (e.filenames ?? []).map((f) => [ensureRelative(projectPath)(f), e]))
-  );
+    const elementMap = new Map(
+      elements.flatMap((e) => (e.filenames ?? []).map((f) => [ensureRelative(projectPath)(f), e]))
+    );
 
-  // iterates the local components and sets their filenames
-  sourceComponents.filter(sourceComponentHasFullNameAndType).map((matchingComponent) => {
-    const filenamesFromMatchingComponent = getAllFiles(matchingComponent);
-    const ignored = filenamesFromMatchingComponent.filter(excludeLwcLocalOnlyTest).some(forceIgnoreDenies(forceIgnore));
-    filenamesFromMatchingComponent.map((filename) => {
-      if (filename && elementMap.has(filename)) {
-        // add the type/name from the componentSet onto the element
-        elementMap.set(filename, {
-          origin: 'remote',
-          ...elementMap.get(filename),
-          type: matchingComponent.type.name,
-          name: matchingComponent.fullName,
-          ignored,
-        });
-      }
+    // iterates the local components and sets their filenames
+    sourceComponents.filter(sourceComponentHasFullNameAndType).map((matchingComponent) => {
+      const filenamesFromMatchingComponent = getAllFiles(matchingComponent);
+      const ignored = filenamesFromMatchingComponent
+        .filter(excludeLwcLocalOnlyTest)
+        .some(forceIgnoreDenies(forceIgnore));
+      filenamesFromMatchingComponent.map((filename) => {
+        if (filename && elementMap.has(filename)) {
+          // add the type/name from the componentSet onto the element
+          elementMap.set(filename, {
+            origin: 'remote',
+            ...elementMap.get(filename),
+            type: matchingComponent.type.name,
+            name: matchingComponent.fullName,
+            ignored,
+          });
+        }
+      });
     });
-  });
-  return excludeUnresolvable
-    ? Array.from(new Set(elementMap.values())).filter(isChangeResultWithNameAndType)
-    : Array.from(new Set(elementMap.values()));
-};
+    return excludeUnresolvable
+      ? Array.from(new Set(elementMap.values())).filter(isChangeResultWithNameAndType)
+      : Array.from(new Set(elementMap.values()));
+  };

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -29,6 +29,8 @@ export type Contents = {
   serverMaxRevisionCounter: number;
   sourceMembers: Record<string, MemberRevision>;
 };
+type MemberRevisionMapEntry = [string, MemberRevision];
+
 const FILENAME = 'maxRevision.json';
 
 /*
@@ -215,7 +217,7 @@ export class RemoteSourceTrackingService {
     // does not match the serverRevisionCounter.
     const returnElements = Array.from(this.sourceMembers.entries())
       .filter(revisionDoesNotMatch)
-      .map(convertRevisionToChange);
+      .map(revisionToRemoteChangeElement);
 
     this.logger.debug(
       returnElements.length
@@ -523,10 +525,7 @@ export const remoteChangeElementToChangeResult = (rce: RemoteChangeElement): Cha
   origin: 'remote', // we know they're remote
 });
 
-const convertRevisionToChange = ([memberKey, memberRevision]: [
-  memberKey: string,
-  memberRevision: MemberRevision
-]): RemoteChangeElement => ({
+const revisionToRemoteChangeElement = ([memberKey, memberRevision]: MemberRevisionMapEntry): RemoteChangeElement => ({
   type: memberRevision.memberType,
   name: memberKey.replace(`${memberRevision.memberType}__`, ''),
   deleted: memberRevision.isNameObsolete,
@@ -622,7 +621,7 @@ const formatSourceMemberWarnings = (outstandingSourceMembers: Map<string, Remote
     .join(EOL);
 };
 
-const revisionDoesNotMatch = ([, member]: [_: unknown, member: MemberRevision]): boolean => doesNotMatchServer(member);
+const revisionDoesNotMatch = ([, member]: MemberRevisionMapEntry): boolean => doesNotMatchServer(member);
 
 const doesNotMatchServer = (member: MemberRevision): boolean =>
   member.serverRevisionCounter !== member.lastRetrievedFromServer;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -88,3 +88,4 @@ export type SourceMemberPollingEvent = {
   attempts: number;
   consecutiveEmptyResults: number;
 };
+export type ChangeResultWithNameAndType = ChangeResult & Required<Pick<ChangeResult, 'name' | 'type'>>;

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -50,7 +50,11 @@ import {
   sourceComponentGuard,
 } from './shared/guards';
 import { removeIgnored } from './shared/remoteChangeIgnoring';
-import { changeResultToMetadataComponent, remoteChangeToMetadataMember } from './shared/functions';
+import {
+  FileResponseSuccessToRemoteSyncInput,
+  changeResultToMetadataComponent,
+  remoteChangeToMetadataMember,
+} from './shared/functions';
 import {
   supportsPartialDelete,
   ensureRelative,
@@ -634,9 +638,7 @@ export class SourceTracking extends AsyncCreatable {
         files: successes.filter(FileResponseIsNotDeleted).map(filePathFromFileResponse),
         deletedFiles: successes.filter(FileResponseIsDeleted).map(filePathFromFileResponse),
       }),
-      this.updateRemoteTracking(
-        successes.map(({ state, fullName, type, filePath }) => ({ state, fullName, type, filePath }))
-      ),
+      this.updateRemoteTracking(successes.map(FileResponseSuccessToRemoteSyncInput)),
     ]);
   }
 
@@ -658,7 +660,7 @@ export class SourceTracking extends AsyncCreatable {
         deletedFiles: successes.filter(FileResponseIsDeleted).filter(FileResponseHasPath).map(filePathFromFileResponse),
       }),
       this.updateRemoteTracking(
-        successes.map(({ state, fullName, type, filePath }) => ({ state, fullName, type, filePath })),
+        successes.map(FileResponseSuccessToRemoteSyncInput),
         true // retrieves don't need to poll for SourceMembers
       ),
     ]);

--- a/test/nuts/local/commitPerf.nut.ts
+++ b/test/nuts/local/commitPerf.nut.ts
@@ -43,6 +43,6 @@ describe('perf testing for big commits', () => {
   it('should sync them locally in a reasonable amount of time', async () => {
     const start = Date.now();
     await repo.commitChanges({ deployedFiles: filesToSync, needsUpdatedStatus: false });
-    expect(Date.now() - start).to.be.lessThan(15000);
+    expect(Date.now() - start).to.be.lessThan(15_000);
   });
 });

--- a/test/nuts/local/partialBundleDelete.nut.ts
+++ b/test/nuts/local/partialBundleDelete.nut.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs';
 import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
+import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import { getComponentSets } from '../../../src/shared/localComponentSetArray';
 
 describe('Bundle-like types delete', () => {
@@ -26,7 +27,7 @@ describe('Bundle-like types delete', () => {
   // We need a sinon sandbox to stub the file system to make it look like we
   // deleted some files.
   const sandbox = sinon.createSandbox();
-
+  const registry = new RegistryAccess();
   after(async () => {
     await session?.clean();
   });
@@ -41,13 +42,16 @@ describe('Bundle-like types delete', () => {
     const lwcJsFile = path.join(lwcTestCompDir, 'myComp.js');
     const lwcMetaFile = path.join(lwcTestCompDir, 'myComp.js-meta.xml');
 
-    const compSets = getComponentSets([
-      {
-        path: path.join(session.project.dir, 'force-app', 'lwc'),
-        nonDeletes: [lwcJsFile, lwcMetaFile],
-        deletes: [lwcHtmlFile],
-      },
-    ]);
+    const compSets = getComponentSets({
+      groupings: [
+        {
+          path: path.join(session.project.dir, 'force-app', 'lwc'),
+          nonDeletes: [lwcJsFile, lwcMetaFile],
+          deletes: [lwcHtmlFile],
+        },
+      ],
+      registry,
+    });
 
     expect(compSets.length).to.equal(1);
     compSets.forEach((cs) => {
@@ -65,13 +69,16 @@ describe('Bundle-like types delete', () => {
     const lwcJsFile = path.join(lwcTestCompDir, 'myComp.js');
     const lwcMetaFile = path.join(lwcTestCompDir, 'myComp.js-meta.xml');
 
-    const compSets = getComponentSets([
-      {
-        path: path.join(session.project.dir, 'force-app', 'lwc'),
-        nonDeletes: [],
-        deletes: [lwcHtmlFile, lwcJsFile, lwcMetaFile],
-      },
-    ]);
+    const compSets = getComponentSets({
+      groupings: [
+        {
+          path: path.join(session.project.dir, 'force-app', 'lwc'),
+          nonDeletes: [],
+          deletes: [lwcHtmlFile, lwcJsFile, lwcMetaFile],
+        },
+      ],
+      registry,
+    });
 
     expect(compSets.length).to.equal(1);
     compSets.forEach((cs) => {
@@ -87,13 +94,16 @@ describe('Bundle-like types delete', () => {
     const srFile2 = path.join(srDir, 'ZippedResource', 'file2.json');
     const srMetaFile = path.join(srDir, 'ZippedResource.resource-meta.xml');
 
-    const compSets = getComponentSets([
-      {
-        path: srDir,
-        nonDeletes: [srMetaFile, srFile2],
-        deletes: [srFile1],
-      },
-    ]);
+    const compSets = getComponentSets({
+      groupings: [
+        {
+          path: srDir,
+          nonDeletes: [srMetaFile, srFile2],
+          deletes: [srFile1],
+        },
+      ],
+      registry,
+    });
 
     expect(compSets.length).to.equal(1);
     compSets.forEach((cs) => {
@@ -111,13 +121,16 @@ describe('Bundle-like types delete', () => {
     const srFile2 = path.join(srDir, 'ZippedResource', 'file2.json');
     const srMetaFile = path.join(srDir, 'ZippedResource.resource-meta.xml');
 
-    const compSets = getComponentSets([
-      {
-        path: srDir,
-        nonDeletes: [],
-        deletes: [srFile1, srFile2, srMetaFile],
-      },
-    ]);
+    const compSets = getComponentSets({
+      groupings: [
+        {
+          path: srDir,
+          nonDeletes: [],
+          deletes: [srFile1, srFile2, srMetaFile],
+        },
+      ],
+      registry,
+    });
 
     expect(compSets.length).to.equal(1);
     compSets.forEach((cs) => {
@@ -131,13 +144,16 @@ describe('Bundle-like types delete', () => {
     const debDir = path.join(session.project.dir, 'force-app', 'digitalExperiences', 'site', 'Xcel_Energy1');
     const deFile1 = path.join(debDir, 'sfdc_cms__view', 'home', 'content.json');
 
-    const compSets = getComponentSets([
-      {
-        path: debDir,
-        nonDeletes: [],
-        deletes: [deFile1],
-      },
-    ]);
+    const compSets = getComponentSets({
+      groupings: [
+        {
+          path: debDir,
+          nonDeletes: [],
+          deletes: [deFile1],
+        },
+      ],
+      registry,
+    });
 
     expect(compSets.length).to.equal(1);
     compSets.forEach((cs) => {
@@ -152,13 +168,16 @@ describe('Bundle-like types delete', () => {
     const eFile1 = path.join(ebDir, 'views', 'login.json');
     const eFile2 = path.join(ebDir, 'routes', 'login.json');
 
-    const compSets = getComponentSets([
-      {
-        path: ebDir,
-        nonDeletes: [eFile2],
-        deletes: [eFile1],
-      },
-    ]);
+    const compSets = getComponentSets({
+      groupings: [
+        {
+          path: ebDir,
+          nonDeletes: [eFile2],
+          deletes: [eFile1],
+        },
+      ],
+      registry,
+    });
 
     expect(compSets.length).to.equal(1);
     compSets.forEach((cs) => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@salesforce/dev-config/tsconfig-test-strict",
   "include": ["./**/*.ts"],
   "compilerOptions": {
-    "skipLibCheck": true,
-    "strictNullChecks": true
+    "skipLibCheck": true
   }
 }

--- a/test/unit/conflicts.test.ts
+++ b/test/unit/conflicts.test.ts
@@ -7,7 +7,7 @@
 import * as path from 'node:path';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { ForceIgnore, ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ForceIgnore, ComponentSet, RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import { findConflictsInComponentSet, getDedupedConflictsFromChanges } from '../../src/shared/conflicts';
 import { ChangeResult } from '../../src/shared/types';
 
@@ -54,13 +54,18 @@ describe('conflicts functions', () => {
     });
   });
   describe('dedupe', () => {
+    const registry = new RegistryAccess();
+    const base = {
+      registry,
+      forceIgnore: forceIgnoreStub,
+      projectPath: 'foo',
+    };
     it('works on empty changes', () => {
       expect(
         getDedupedConflictsFromChanges({
           localChanges: [],
           remoteChanges: [],
-          projectPath: 'foo',
-          forceIgnore: forceIgnoreStub,
+          ...base,
         })
       ).to.deep.equal([]);
     });
@@ -69,8 +74,7 @@ describe('conflicts functions', () => {
         getDedupedConflictsFromChanges({
           localChanges: [class1Local],
           remoteChanges: [],
-          projectPath: 'foo',
-          forceIgnore: forceIgnoreStub,
+          ...base,
         })
       ).to.deep.equal([]);
     });
@@ -86,8 +90,7 @@ describe('conflicts functions', () => {
               filenames: ['foo/classes/OtherClass.cls', 'foo/classes/OtherClass.cls-meta.xml'],
             },
           ],
-          projectPath: 'foo',
-          forceIgnore: forceIgnoreStub,
+          ...base,
         })
       ).to.deep.equal([]);
     });
@@ -99,8 +102,7 @@ describe('conflicts functions', () => {
         getDedupedConflictsFromChanges({
           localChanges: [class1Local],
           remoteChanges: [{ origin: 'remote', name: 'MyClass', type: 'ApexClass' }],
-          projectPath: 'foo',
-          forceIgnore: forceIgnoreStub,
+          ...base,
         })
       ).to.deep.equal([{ ...simplifiedResult, origin: 'remote' }]);
     });

--- a/test/unit/deleteCustomLabels.test.ts
+++ b/test/unit/deleteCustomLabels.test.ts
@@ -6,9 +6,13 @@
  */
 import * as fs from 'node:fs';
 import * as sinon from 'sinon';
-import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { SourceComponent, RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import { expect } from 'chai';
 import { deleteCustomLabels } from '../../src/';
+
+const registry = new RegistryAccess();
+// const customLabelsType = registry.getTypeByName('CustomLabels');
+const customLabelType = registry.getTypeByName('CustomLabel');
 
 describe('deleteCustomLabels', () => {
   const sandbox = sinon.createSandbox();
@@ -57,7 +61,7 @@ describe('deleteCustomLabels', () => {
     it('will delete a singular custom label from a file', async () => {
       const labels = [
         {
-          type: { id: 'customlabel', name: 'CustomLabel' },
+          type: customLabelType,
           fullName: 'DeleteMe',
         } as SourceComponent,
       ];
@@ -70,11 +74,11 @@ describe('deleteCustomLabels', () => {
     it('will delete a multiple custom labels from a file', async () => {
       const labels = [
         {
-          type: { id: 'customlabel', name: 'CustomLabel' },
+          type: customLabelType,
           fullName: 'KeepMe1',
         },
         {
-          type: { id: 'customlabel', name: 'CustomLabel' },
+          type: customLabelType,
           fullName: 'KeepMe2',
         },
       ] as SourceComponent[];
@@ -88,15 +92,15 @@ describe('deleteCustomLabels', () => {
     it('will delete the file when everything is deleted', async () => {
       const labels = [
         {
-          type: { id: 'customlabel', name: 'CustomLabel' },
+          type: customLabelType,
           fullName: 'KeepMe1',
         },
         {
-          type: { id: 'customlabel', name: 'CustomLabel' },
+          type: customLabelType,
           fullName: 'KeepMe2',
         },
         {
-          type: { id: 'customlabel', name: 'CustomLabel' },
+          type: customLabelType,
           fullName: 'DeleteMe',
         },
       ] as SourceComponent[];
@@ -122,7 +126,7 @@ describe('deleteCustomLabels', () => {
       );
       const labels = [
         {
-          type: { id: 'customlabel', name: 'CustomLabel' },
+          type: customLabelType,
           fullName: 'DeleteMe',
         },
       ] as SourceComponent[];

--- a/test/unit/localShadowRepo.test.ts
+++ b/test/unit/localShadowRepo.test.ts
@@ -117,7 +117,7 @@ describe('localShadowRepo', () => {
     // private property maxFileAdd
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    expect(shadowRepo.maxFileAdd).to.equal(os.type() === 'Windows_NT' ? 8000 : 15000);
+    expect(shadowRepo.maxFileAdd).to.equal(os.type() === 'Windows_NT' ? 8000 : 15_000);
     expect(process.env.SF_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
     expect(process.env.SFDX_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
   });

--- a/test/unit/pathIsInFolder.test.ts
+++ b/test/unit/pathIsInFolder.test.ts
@@ -10,27 +10,27 @@ import { pathIsInFolder } from '../../src/shared/functions';
 
 describe('pathIsInFolder', () => {
   it('does not misidentify partial strings', () => {
-    expect(pathIsInFolder(normalize('/foo/bar-extra/baz'), normalize('/foo/bar'))).to.equal(false);
+    expect(pathIsInFolder(normalize('/foo/bar'))(normalize('/foo/bar-extra/baz'))).to.equal(false);
   });
 
   it('does not misidentify partial strings (inverse)', () => {
-    expect(pathIsInFolder(normalize('/foo/bar-extra/baz'), normalize('/foo/bar-extra'))).to.equal(true);
+    expect(pathIsInFolder(normalize('/foo/bar-extra'))(normalize('/foo/bar-extra/baz'))).to.equal(true);
   });
 
   it('single top-level dir is ok', () => {
-    expect(pathIsInFolder(normalize('/foo/bar-extra/baz'), normalize('/foo'))).to.equal(true);
+    expect(pathIsInFolder(normalize('/foo'))(normalize('/foo/bar-extra/baz'))).to.equal(true);
   });
 
   it('no initial separator on 1st arg is ok', () => {
-    expect(pathIsInFolder(normalize('/foo/bar-extra/baz'), 'foo')).to.equal(true);
+    expect(pathIsInFolder('foo')(normalize('/foo/bar-extra/baz'))).to.equal(true);
   });
 
   it('no initial separator on 2nd arg is ok', () => {
-    expect(pathIsInFolder(normalize('foo/bar-extra/baz'), normalize('/foo'))).to.equal(true);
+    expect(pathIsInFolder(normalize('/foo'))(normalize('foo/bar-extra/baz'))).to.equal(true);
   });
 
   it('works for deep children', () => {
-    expect(pathIsInFolder(normalize('/foo/bar-extra/baz/some/deep/path'), normalize('/foo/bar-extra/baz'))).to.equal(
+    expect(pathIsInFolder(normalize('/foo/bar-extra/baz'))(normalize('/foo/bar-extra/baz/some/deep/path'))).to.equal(
       true
     );
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./lib",
     "skipLibCheck": true,
-    "strictNullChecks": true,
     "plugins": [{ "transform": "@salesforce/core/lib/messageTransformer", "import": "messageTransformer" }]
   },
   "include": ["src/**/*.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,10 +592,34 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.0"
 
-"@salesforce/core@^6.7.0", "@salesforce/core@^6.7.1":
+"@salesforce/core@^6.7.0":
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.7.1.tgz#4dcfb62bc3d488462ea6e9438ff092cf202c1696"
   integrity sha512-SxscNdH2l+K5LmqH9XrosX+fjhPkMLN3hsG50sWQi7DbaI1Z0FGAKVOmVe6fZZsUsVNThKvZ+159IwwtxHWY6w==
+  dependencies:
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/schemas" "^1.6.1"
+    "@salesforce/ts-types" "^2.0.9"
+    "@types/semver" "^7.5.8"
+    ajv "^8.12.0"
+    change-case "^4.1.2"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.29"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^8.19.0"
+    pino-abstract-transport "^1.1.0"
+    pino-pretty "^10.3.1"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.0"
+    ts-retry-promise "^0.7.1"
+
+"@salesforce/core@^6.7.3":
+  version "6.7.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.7.3.tgz#5d8f30c40ac3cebb898c8e845fe9a067bc729268"
+  integrity sha512-uU+PuZZGXxByhvnXLH1V3eY5P1caw401dIZ/QvhzYxoP/alPLk7dpChnZNJYH5Rw3dc/AhSPw+eg0cvUyjhP1Q==
   dependencies:
     "@salesforce/kit" "^3.0.15"
     "@salesforce/schemas" "^1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,31 +592,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.0"
 
-"@salesforce/core@^6.7.0":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.7.1.tgz#4dcfb62bc3d488462ea6e9438ff092cf202c1696"
-  integrity sha512-SxscNdH2l+K5LmqH9XrosX+fjhPkMLN3hsG50sWQi7DbaI1Z0FGAKVOmVe6fZZsUsVNThKvZ+159IwwtxHWY6w==
-  dependencies:
-    "@salesforce/kit" "^3.0.15"
-    "@salesforce/schemas" "^1.6.1"
-    "@salesforce/ts-types" "^2.0.9"
-    "@types/semver" "^7.5.8"
-    ajv "^8.12.0"
-    change-case "^4.1.2"
-    faye "^1.4.0"
-    form-data "^4.0.0"
-    js2xmlparser "^4.0.1"
-    jsforce "^2.0.0-beta.29"
-    jsonwebtoken "9.0.2"
-    jszip "3.10.1"
-    pino "^8.19.0"
-    pino-abstract-transport "^1.1.0"
-    pino-pretty "^10.3.1"
-    proper-lockfile "^4.1.2"
-    semver "^7.6.0"
-    ts-retry-promise "^0.7.1"
-
-"@salesforce/core@^6.7.3":
+"@salesforce/core@^6.7.0", "@salesforce/core@^6.7.3":
   version "6.7.3"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.7.3.tgz#5d8f30c40ac3cebb898c8e845fe9a067bc729268"
   integrity sha512-uU+PuZZGXxByhvnXLH1V3eY5P1caw401dIZ/QvhzYxoP/alPLk7dpChnZNJYH5Rw3dc/AhSPw+eg0cvUyjhP1Q==
@@ -677,10 +653,10 @@
     typescript "^4.9.5"
     wireit "^0.14.4"
 
-"@salesforce/kit@^3.0.15":
-  version "3.0.15"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.0.15.tgz#713df3f5767f874c70a2e731c7cb5ba677989559"
-  integrity sha512-XkA8jsuLvVnyP460dAbU3pBFP2IkmmmsVxMQVifcKKbNWaIBbZBzAfj+vdaQfnvZyflLhsrFT3q2xkb0vHouPg==
+"@salesforce/kit@^3.0.15", "@salesforce/kit@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.0.tgz#aa42533084c676e865f0f9c1907a16fb6f74dee7"
+  integrity sha512-X2d9O/U2wdQBXIrtVqQdMwo872Cv+qkYFzF0W+AQKG/LEe9cngnOzUVDYNkGD9tq3jcl+oenHXYuVDpkMhxTwA==
   dependencies:
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -671,10 +671,10 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.1.tgz#7d1c071e1e509ca9d2d8a6e48ac7447dd67a534d"
   integrity sha512-eVy947ZMxCJReKJdgfddUIsBIbPTa/i8RwQGwxq4/ss38H5sLOAeSTaun9V7HpJ1hkpDznWKfgzYvjsst9K6ig==
 
-"@salesforce/source-deploy-retrieve@^10.6.0":
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.6.0.tgz#7052063d7af27cc570af27391d893f0991236a77"
-  integrity sha512-XmeCR8vcxfLF0u11kf/FjJMYIo05bRN3/pdrcqsJ8pNOI4fD9Lq6ef8VbutPSxHKaxqpdgHUAaRLb4pPSIeVMQ==
+"@salesforce/source-deploy-retrieve@^10.6.1":
+  version "10.6.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.6.1.tgz#d153168c5870ce051a6e397df00083da1e6a8106"
+  integrity sha512-AdX0rlMNw88kD4jTqdW7uxl6wTd+WTESHEH5Vj8e9Fj2cC8pZj5BwDMYbU/cVFFbQoEBjqqnxwJC6ziPw83Bsw==
   dependencies:
     "@salesforce/core" "^6.7.3"
     "@salesforce/kit" "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,10 +538,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oclif/core@^3.25.2":
-  version "3.25.2"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.25.2.tgz#a26d56abe5686c57c1e973957777bd2ae324e973"
-  integrity sha512-OkW/cNa/3DhoCz2YlSpymVe8DXqkoRaLY4SPTVqNVzR4R1dFBE5KoCtuwKwnhxYLCRCqaViPgRnB5K26f0MnjA==
+"@oclif/core@^3.26.0":
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.26.0.tgz#959d5e9f13f4ad6a4e98235ad125189df9ee4279"
+  integrity sha512-TpMdfD4tfA2tVVbd4l0PrP02o5KoUXYmudBbTC7CeguDo/GLoprw4uL8cMsaVA26+cbcy7WYtOEydQiHVtJixA==
   dependencies:
     "@types/cli-progress" "^3.11.5"
     ansi-escapes "^4.3.2"
@@ -577,12 +577,12 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@salesforce/cli-plugins-testkit@^5.1.10":
-  version "5.1.10"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.1.10.tgz#949738717513b1518c09bd70690cb2963073a59d"
-  integrity sha512-zAyv6luZSjJFOa/v0IHYAfNcWSl1DTZ7l5cJalKTuu7oXfy0mskZO4KzPZ4vdyBSz54t6+yXgNA2C/uFyqe/CQ==
+"@salesforce/cli-plugins-testkit@^5.1.12":
+  version "5.1.12"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.1.12.tgz#b453a7b99940d6f5c9e64d7432b60b44b682747b"
+  integrity sha512-dICcYW2dejeOtA8fMYCyTCl/PXfYLoNlVPL18ATpR3pEDUjlyI1JWY0GE8chhqCsr0TgDBkkd/MKuUiTSsGebQ==
   dependencies:
-    "@salesforce/core" "^6.7.0"
+    "@salesforce/core" "^6.7.3"
     "@salesforce/kit" "^3.0.15"
     "@salesforce/ts-types" "^2.0.9"
     "@types/shelljs" "^0.8.15"
@@ -671,13 +671,13 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.1.tgz#7d1c071e1e509ca9d2d8a6e48ac7447dd67a534d"
   integrity sha512-eVy947ZMxCJReKJdgfddUIsBIbPTa/i8RwQGwxq4/ss38H5sLOAeSTaun9V7HpJ1hkpDznWKfgzYvjsst9K6ig==
 
-"@salesforce/source-deploy-retrieve@^10.5.2":
-  version "10.5.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.5.2.tgz#aecf7147f48c65286c92fdba20f8a2ed289fd58e"
-  integrity sha512-J82cNDJF7gA1/VQ/igfpR2Aa31htDvym5LnGJv2Yhd3BRaa7kTR8lJdzseN8m/EFrBfqYfRT14yzSewsR686EQ==
+"@salesforce/source-deploy-retrieve@^10.6.0":
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.6.0.tgz#7052063d7af27cc570af27391d893f0991236a77"
+  integrity sha512-XmeCR8vcxfLF0u11kf/FjJMYIo05bRN3/pdrcqsJ8pNOI4fD9Lq6ef8VbutPSxHKaxqpdgHUAaRLb4pPSIeVMQ==
   dependencies:
-    "@salesforce/core" "^6.7.0"
-    "@salesforce/kit" "^3.0.15"
+    "@salesforce/core" "^6.7.3"
+    "@salesforce/kit" "^3.1.0"
     "@salesforce/ts-types" "^2.0.9"
     fast-levenshtein "^3.0.0"
     fast-xml-parser "^4.3.5"
@@ -5664,10 +5664,10 @@ typedoc@^0.25.9:
     minimatch "^9.0.3"
     shiki "^0.14.7"
 
-"typescript@^4.6.4 || ^5.0.0", typescript@^5.4.2:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
-  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
+"typescript@^4.6.4 || ^5.0.0", typescript@^5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
+  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
 
 typescript@^4.9.5:
   version "4.9.5"


### PR DESCRIPTION
> requires https://github.com/forcedotcom/source-deploy-retrieve/pull/1217

### What does this PR do?
componentSet and Resolver allow the passing in a registry.

STL will now resolve the registry once when instantiated, from the projectDir, and pass that around to everything that needs it.

### What issues does this PR fix or reference?
part of making @W-14608988@ work with tracking