### PR TITLE
fix: show iso-git err qty in logs

### DIFF
--- a/src/shared/localShadowRepo.ts
+++ b/src/shared/localShadowRepo.ts
@@ -280,7 +280,7 @@ export class ShadowRepo {
           });
         } catch (e) {
           if (e instanceof git.Errors.MultipleGitError) {
-            this.logger.error('multiple errors on git.add', e.errors.slice(0, 5));
+            this.logger.error(`${e.errors.length} errors on git.add, showing the first 5:`, e.errors.slice(0, 5));
             const error = new SfError(
               e.message,
               e.name,


### PR DESCRIPTION
### What does this PR do?
updates debug log about isogit error to show qty of errors (logs only include the first 5).

### What issues does this PR fix or reference?
@W-15347866@