### PR TITLE
chore: add workflow to publish source-tracking-bundle

### DIFF
--- a/.github/workflows/releaseWithCoreBundle.yml
+++ b/.github/workflows/releaseWithCoreBundle.yml
@@ -1,0 +1,16 @@
+name: publish source-tracking-bundle
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Set the branch to use for release'
+        type: string
+        required: false
+        default: 'main'
+
+jobs:
+  call-release-workflow:
+    uses: forcedotcom/bundle-publish-scripts/.github/workflows/releaseWithCoreBundle.yml@main
+    secrets: inherit
+    with:
+      branch: ${{ inputs.branch }}


### PR DESCRIPTION
### What does this PR do?
This PR is to add a workflow to publish source-tracking-bundle in order to be consumed by vs code extensions repo

### What issues does this PR fix or reference?
@W-15288779@