### PR TITLE
fix: memory usage on giant repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oclif/core": "^3.26.6",
     "@salesforce/core": "^7.3.9",
     "@salesforce/kit": "^3.1.2",
-    "@salesforce/source-deploy-retrieve": "^11.6.2",
+    "@salesforce/source-deploy-retrieve": "^11.6.3",
     "@salesforce/ts-types": "^2.0.9",
     "fast-xml-parser": "^4.3.6",
     "graceful-fs": "^4.2.11",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   },
   "dependencies": {
     "@oclif/core": "^3.26.6",
-    "@salesforce/core": "^7.3.8",
+    "@salesforce/core": "^7.3.9",
     "@salesforce/kit": "^3.1.1",
-    "@salesforce/source-deploy-retrieve": "^11.4.4",
+    "@salesforce/source-deploy-retrieve": "^11.6.2",
     "@salesforce/ts-types": "^2.0.9",
     "fast-xml-parser": "^4.3.6",
     "graceful-fs": "^4.2.11",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@oclif/core": "^3.26.6",
     "@salesforce/core": "^7.3.9",
-    "@salesforce/kit": "^3.1.1",
+    "@salesforce/kit": "^3.1.2",
     "@salesforce/source-deploy-retrieve": "^11.6.2",
     "@salesforce/ts-types": "^2.0.9",
     "fast-xml-parser": "^4.3.6",

--- a/src/shared/local/functions.ts
+++ b/src/shared/local/functions.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'node:path';
+import { WORKDIR, HEAD } from './localShadowRepo';
+import { FILE } from './localShadowRepo';
+
+import { StatusRow } from './types';
+
+// filenames were normalized when read from isogit
+
+export const toFilenames = (rows: StatusRow[]): string[] => rows.map((row) => row[FILE]);
+export const isDeleted = (status: StatusRow): boolean => status[WORKDIR] === 0;
+export const isAdded = (status: StatusRow): boolean => status[HEAD] === 0 && status[WORKDIR] === 2;
+export const ensureWindows = (filepath: string): string => path.win32.normalize(filepath);

--- a/src/shared/local/localShadowRepo.ts
+++ b/src/shared/local/localShadowRepo.ts
@@ -17,8 +17,7 @@ import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import { chunkArray, excludeLwcLocalOnlyTest, folderContainsPath } from '../functions';
 import { filenameMatchesToMap, getMatches } from './moveDetection';
 import { StatusRow } from './types';
-import { toFilenames } from './functions';
-import { isDeleted, isAdded } from './functions';
+import { isDeleted, isAdded, toFilenames } from './functions';
 
 /** returns the full path to where we store the shadow repo */
 const getGitDir = (orgId: string, projectPath: string): string =>

--- a/src/shared/local/moveDetection.ts
+++ b/src/shared/local/moveDetection.ts
@@ -191,7 +191,7 @@ const getHashForAddedFile =
   async (filepath: string): Promise<FilenameBasenameHash> => ({
     filename: filepath,
     basename: path.basename(filepath),
-    hash: (await git.hashBlob({ object: await fs.promises.readFile(path.join(projectPath, filepath), 'utf8') })).oid,
+    hash: (await git.hashBlob({ object: await fs.promises.readFile(path.join(projectPath, filepath)) })).oid,
   });
 
 const resolveType = (resolver: MetadataResolver, filenames: string[]): SourceComponent[] =>

--- a/src/shared/local/moveDetection.ts
+++ b/src/shared/local/moveDetection.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'node:path';
+import { Logger, Lifecycle } from '@salesforce/core';
+import {
+  MetadataResolver,
+  SourceComponent,
+  RegistryAccess,
+  VirtualTreeContainer,
+} from '@salesforce/source-deploy-retrieve';
+// @ts-expect-error isogit has both ESM and CJS exports but node16 module/resolution identifies it as ESM
+import git from 'isomorphic-git';
+import * as fs from 'graceful-fs';
+import { sourceComponentGuard } from '../guards';
+import { isDeleted, isAdded, ensureWindows, toFilenames } from './functions';
+import { AddAndDeleteMaps, FileInfo, StatusRow, StringMap } from './types';
+
+/** compare delete and adds from git.status, matching basenames of the files.  returns early when there's nothing to match */
+export const getMatches = (
+  status: StatusRow[]
+): { deletedFilenamesWithMatches: Set<string>; addedFilenamesWithMatches: Set<string> } | undefined => {
+  // We check for moved files in incremental steps and exit as early as we can to avoid any performance degradation
+  // Deleted files will be more rare than added files, so we'll check them first and exit early if there are none
+  const deletedFiles = status.filter(isDeleted);
+  if (!deletedFiles.length) return;
+
+  const addedFiles = status.filter(isAdded);
+  if (!addedFiles.length) return;
+
+  // Both arrays have contents, look for matching basenames
+  const addedFilenames = toFilenames(addedFiles);
+  const deletedFilenames = toFilenames(deletedFiles);
+
+  // Build Sets of basenames for added and deleted files for quick lookups
+  const addedBasenames = new Set(addedFilenames.map((filename) => path.basename(filename)));
+  const deletedBasenames = new Set(deletedFilenames.map((filename) => path.basename(filename)));
+
+  // Again, we filter over the deleted files first and exit early if there are no filename matches
+  const deletedFilenamesWithMatches = new Set(deletedFilenames.filter((f) => addedBasenames.has(path.basename(f))));
+  if (!deletedFilenamesWithMatches.size) return;
+
+  const addedFilenamesWithMatches = new Set(addedFilenames.filter((f) => deletedBasenames.has(path.basename(f))));
+  if (!addedFilenamesWithMatches.size) return;
+
+  return { addedFilenamesWithMatches, deletedFilenamesWithMatches };
+};
+
+export const getHash =
+  (gitdir: string) =>
+  (projectPath: string) =>
+  (oid: string) =>
+  async (filepath: string): Promise<FileInfo> => ({
+    filename: filepath,
+    basename: path.basename(filepath),
+    hash: (await git.readBlob({ fs, dir: projectPath, gitdir, filepath, oid })).oid,
+  });
+
+/** build maps of the add/deletes with filenames, returning the matches  Logs if non-matches */
+export const buildMaps = async (addedInfo: FileInfo[], deletedInfo: FileInfo[]): Promise<AddAndDeleteMaps> => {
+  const [addedMap, addedIgnoredMap] = buildMap(addedInfo);
+  const [deletedMap, deletedIgnoredMap] = buildMap(deletedInfo);
+
+  // If we detected any files that have the same basename and hash, emit a warning and send telemetry
+  // These files will still show up as expected in the `sf project deploy preview` output
+  // We could add more logic to determine and display filepaths that we ignored...
+  // but this is likely rare enough to not warrant the added complexity
+  // Telemetry will help us determine how often this occurs
+  if (addedIgnoredMap.size || deletedIgnoredMap.size) {
+    const message = 'Files were found that have the same basename and hash. Skipping the commit of these files';
+    const logger = Logger.childFromRoot('ShadowRepo.compareHashes');
+    logger.warn(message);
+    const lifecycle = Lifecycle.getInstance();
+    await Promise.all([
+      lifecycle.emitWarning(message),
+      lifecycle.emitTelemetry({ eventName: 'moveFileHashBasenameCollisionsDetected' }),
+    ]);
+  }
+  return { addedMap, deletedMap };
+};
+
+/** builds a map of the values from both maps */
+export const compareHashes = ({ addedMap, deletedMap }: AddAndDeleteMaps): StringMap => {
+  const matches: StringMap = new Map();
+
+  for (const [addedKey, addedValue] of addedMap) {
+    const deletedValue = deletedMap.get(addedKey);
+    if (deletedValue) {
+      matches.set(addedValue, deletedValue);
+    }
+  }
+
+  return matches;
+};
+
+export const buildMap = (info: FileInfo[]): StringMap[] => {
+  const map: StringMap = new Map();
+  const ignore: StringMap = new Map();
+  info.map((i) => {
+    const key = `${i.hash}#${i.basename}`;
+    // If we find a duplicate key, we need to remove it and ignore it in the future.
+    // Finding duplicate hash#basename means that we cannot accurately determine where it was moved to or from
+    if (map.has(key) || ignore.has(key)) {
+      map.delete(key);
+      ignore.set(key, i.filename);
+    } else {
+      map.set(key, i.filename);
+    }
+  });
+  return [map, ignore];
+};
+
+export const removeNonMatches = (matches: StringMap, registry: RegistryAccess, isWindows: boolean): StringMap => {
+  const addedFiles = isWindows ? [...matches.keys()].map(ensureWindows) : [...matches.keys()];
+  const deletedFiles = isWindows ? [...matches.values()].map(ensureWindows) : [...matches.values()];
+  const resolverAdded = new MetadataResolver(registry, VirtualTreeContainer.fromFilePaths(addedFiles));
+  const resolverDeleted = new MetadataResolver(registry, VirtualTreeContainer.fromFilePaths(deletedFiles));
+
+  return new Map(
+    [...matches.entries()].filter(([addedFile, deletedFile]) => {
+      // we're only ever using the first element of the arrays
+      const [resolvedAdded] = resolveType(resolverAdded, isWindows ? [ensureWindows(addedFile)] : [addedFile]);
+      const [resolvedDeleted] = resolveType(resolverDeleted, isWindows ? [ensureWindows(deletedFile)] : [deletedFile]);
+      return (
+        // they could match, or could both be undefined (because unresolved by SDR)
+        resolvedAdded?.type.name === resolvedDeleted?.type.name &&
+        // parent names match, if resolved and there are parents
+        resolvedAdded?.parent?.name === resolvedDeleted?.parent?.name &&
+        // parent types match, if resolved and there are parents
+        resolvedAdded?.parent?.type.name === resolvedDeleted?.parent?.type.name
+      );
+    })
+  );
+};
+
+const resolveType = (resolver: MetadataResolver, filenames: string[]): SourceComponent[] =>
+  filenames
+    .flatMap((filename) => {
+      try {
+        return resolver.getComponentsFromPath(filename);
+      } catch (e) {
+        const logger = Logger.childFromRoot('ShadowRepo.compareTypes');
+        logger.warn(`unable to resolve ${filename}`);
+        return undefined;
+      }
+    })
+    .filter(sourceComponentGuard);

--- a/src/shared/local/moveDetection.ts
+++ b/src/shared/local/moveDetection.ts
@@ -62,6 +62,7 @@ export const getMatches = (status: StatusRow[]): AddedAndDeletedFilenames => {
   const addedBasenames = new Set(addedFilenames.map((filename) => path.basename(filename)));
   const deletedBasenames = new Set(deletedFilenames.map((filename) => path.basename(filename)));
 
+  // TODO: when node 22 is everywhere, we can use Set.prototype.intersection
   // Again, we filter over the deleted files first and exit early if there are no filename matches
   const deletedFilenamesWithMatches = new Set(deletedFilenames.filter((f) => addedBasenames.has(path.basename(f))));
   if (!deletedFilenamesWithMatches.size) return emptyResult;

--- a/src/shared/local/types.ts
+++ b/src/shared/local/types.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-export type FileInfo = { filename: string; hash: string; basename: string };
+export type FilenameBasenameHash = { filename: string; hash: string; basename: string };
 export type StringMap = Map<string, string>;
 export type AddAndDeleteMaps = { addedMap: StringMap; deletedMap: StringMap }; // https://isomorphic-git.org/docs/en/statusMatrix#docsNav
 

--- a/src/shared/local/types.ts
+++ b/src/shared/local/types.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export type FileInfo = { filename: string; hash: string; basename: string };
+export type StringMap = Map<string, string>;
+export type AddAndDeleteMaps = { addedMap: StringMap; deletedMap: StringMap }; // https://isomorphic-git.org/docs/en/statusMatrix#docsNav
+
+export type StatusRow = [file: string, head: number, workdir: number, stage: number];

--- a/src/sourceTracking.ts
+++ b/src/sourceTracking.ts
@@ -30,7 +30,7 @@ import {
 import { filePathsFromMetadataComponent } from '@salesforce/source-deploy-retrieve/lib/src/utils/filePathGenerator';
 import { Performance } from '@oclif/core';
 import { RemoteSourceTrackingService, remoteChangeElementToChangeResult } from './shared/remoteSourceTrackingService';
-import { ShadowRepo } from './shared/localShadowRepo';
+import { ShadowRepo } from './shared/local/localShadowRepo';
 import { throwIfConflicts, findConflictsInComponentSet, getDedupedConflictsFromChanges } from './shared/conflicts';
 import {
   RemoteSyncInput,

--- a/test/nuts/local/commitPerf.nut.ts
+++ b/test/nuts/local/commitPerf.nut.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 
 describe('perf testing for big commits', () => {
   let session: TestSession;

--- a/test/nuts/local/localTrackingFileMovesDecomposedChild.nut.ts
+++ b/test/nuts/local/localTrackingFileMovesDecomposedChild.nut.ts
@@ -10,7 +10,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import * as fs from 'graceful-fs';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 
 /* eslint-disable no-unused-expressions */
 

--- a/test/nuts/local/localTrackingFileMovesDecomposedChild.nut.ts
+++ b/test/nuts/local/localTrackingFileMovesDecomposedChild.nut.ts
@@ -15,9 +15,10 @@ import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 /* eslint-disable no-unused-expressions */
 
 describe('ignores moved files that are children of a decomposed metadata type', () => {
+  const FIELD = path.join('fields', 'Account__c.field-meta.xml');
   let session: TestSession;
   let repo: ShadowRepo;
-  let filesToSync: string[];
+  let objectsDir: string;
 
   before(async () => {
     session = await TestSession.create({
@@ -26,10 +27,15 @@ describe('ignores moved files that are children of a decomposed metadata type', 
       },
       devhubAuthStrategy: 'NONE',
     });
+    objectsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'objects');
   });
 
   after(async () => {
     await session?.clean();
+  });
+
+  afterEach(() => {
+    delete process.env.SF_BETA_TRACK_FILE_MOVES;
   });
 
   it('initialize the local tracking', async () => {
@@ -44,32 +50,12 @@ describe('ignores moved files that are children of a decomposed metadata type', 
   it('should ignore moved child metadata', async () => {
     expect(process.env.SF_BETA_TRACK_FILE_MOVES).to.be.undefined;
     process.env.SF_BETA_TRACK_FILE_MOVES = 'true';
-    // Commit the existing class files
-    filesToSync = await repo.getChangedFilenames();
+    // Commit the existing files
+    const filesToSync = await repo.getChangedFilenames();
     await repo.commitChanges({ deployedFiles: filesToSync });
-
-    // move all the classes to the new folder
-    const objectFieldOld = path.join(
-      session.project.dir,
-      'force-app',
-      'main',
-      'default',
-      'objects',
-      'Order__c',
-      'fields',
-      'Account__c.field-meta.xml'
-    );
-    const objectFieldNew = path.join(
-      session.project.dir,
-      'force-app',
-      'main',
-      'default',
-      'objects',
-      'Product__c',
-      'fields',
-      'Account__c.field-meta.xml'
-    );
-    // fs.mkdirSync(path.join(session.project.dir, 'force-app', 'main', 'foo'), { recursive: true });
+    // move the field from one object to another
+    const objectFieldOld = path.join(objectsDir, 'Order__c', FIELD);
+    const objectFieldNew = path.join(objectsDir, 'Product__c', FIELD);
     fs.renameSync(objectFieldOld, objectFieldNew);
 
     await repo.getStatus(true);
@@ -78,6 +64,27 @@ describe('ignores moved files that are children of a decomposed metadata type', 
       .to.be.an('array')
       .with.lengthOf(2);
 
-    delete process.env.SF_BETA_TRACK_FILE_MOVES;
+    // put it back how it was and verify the tracking
+    fs.renameSync(objectFieldNew, objectFieldOld);
+    await repo.getStatus(true);
+
+    expect(await repo.getChangedFilenames())
+      .to.be.an('array')
+      .with.lengthOf(0);
+  });
+
+  it('should clear tracking when the field is moved to another dir', async () => {
+    const newDir = path.join(session.project.dir, 'force-app', 'other', 'objects', 'Order__c', 'fields');
+    await fs.promises.mkdir(newDir, {
+      recursive: true,
+    });
+    const objectFieldOld = path.join(objectsDir, 'Order__c', FIELD);
+    const objectFieldNew = path.join(objectsDir, 'Order__c', FIELD);
+    fs.renameSync(objectFieldOld, objectFieldNew);
+    await repo.getStatus(true);
+
+    expect(await repo.getChangedFilenames())
+      .to.be.an('array')
+      .with.lengthOf(0);
   });
 });

--- a/test/nuts/local/localTrackingFileMovesImage.nut.ts
+++ b/test/nuts/local/localTrackingFileMovesImage.nut.ts
@@ -10,7 +10,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import * as fs from 'graceful-fs';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 
 /* eslint-disable no-unused-expressions */
 

--- a/test/nuts/local/localTrackingFileMovesImage.nut.ts
+++ b/test/nuts/local/localTrackingFileMovesImage.nut.ts
@@ -19,6 +19,7 @@ describe('it detects image file moves ', () => {
   let session: TestSession;
   let repo: ShadowRepo;
   let filesToSync: string[];
+  let staticDir: string;
 
   before(async () => {
     session = await TestSession.create({
@@ -27,6 +28,7 @@ describe('it detects image file moves ', () => {
       },
       devhubAuthStrategy: 'NONE',
     });
+    staticDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'staticresources');
   });
 
   after(async () => {
@@ -50,28 +52,12 @@ describe('it detects image file moves ', () => {
     await repo.commitChanges({ deployedFiles: filesToSync });
 
     // move all the classes to the new folder
-    fs.mkdirSync(path.join(session.project.dir, 'force-app', 'main', 'default', 'staticresources', 'bike_assets_new'), {
+    fs.mkdirSync(path.join(staticDir, 'bike_assets_new'), {
       recursive: true,
     });
     fs.renameSync(
-      path.join(
-        session.project.dir,
-        'force-app',
-        'main',
-        'default',
-        'staticresources',
-        'bike_assets',
-        'CyclingGrass.jpg'
-      ),
-      path.join(
-        session.project.dir,
-        'force-app',
-        'main',
-        'default',
-        'staticresources',
-        'bike_assets_new',
-        'CyclingGrass.jpg'
-      )
+      path.join(staticDir, 'bike_assets', 'CyclingGrass.jpg'),
+      path.join(staticDir, 'bike_assets_new', 'CyclingGrass.jpg')
     );
 
     await repo.getStatus(true);

--- a/test/nuts/local/localTrackingFileMovesScale.nut.ts
+++ b/test/nuts/local/localTrackingFileMovesScale.nut.ts
@@ -10,7 +10,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import * as fs from 'graceful-fs';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 
 /* eslint-disable no-unused-expressions */
 

--- a/test/nuts/local/localTrackingFileMovesScale.nut.ts
+++ b/test/nuts/local/localTrackingFileMovesScale.nut.ts
@@ -18,6 +18,8 @@ const dirCount = 20;
 const classesPerDir = 50;
 const classCount = dirCount * classesPerDir;
 
+const nonProjDirFiles = 100_000;
+
 describe(`handles local files moves of ${classCount.toLocaleString()} classes (${(
   classCount * 2
 ).toLocaleString()} files across ${dirCount.toLocaleString()} folders)`, () => {
@@ -32,6 +34,11 @@ describe(`handles local files moves of ${classCount.toLocaleString()} classes ($
       },
       devhubAuthStrategy: 'NONE',
     });
+    const notProjectDir = path.join(session.project.dir, 'not-project-dir');
+    await fs.promises.mkdir(notProjectDir);
+    for (let i = 0; i < nonProjDirFiles; i++) {
+      fs.writeFileSync(path.join(notProjectDir, `file${i}.txt`), 'hello');
+    }
     // create some number of files
     const classdir = path.join(session.project.dir, 'force-app', 'main', 'default', 'classes');
     for (let d = 0; d < dirCount; d++) {

--- a/test/nuts/local/localTrackingScale.nut.ts
+++ b/test/nuts/local/localTrackingScale.nut.ts
@@ -10,7 +10,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import * as fs from 'graceful-fs';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 
 const dirCount = 200;
 const classesPerDir = 500;

--- a/test/nuts/local/localTrackingScenario.nut.ts
+++ b/test/nuts/local/localTrackingScenario.nut.ts
@@ -11,7 +11,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { shouldThrow } from '@salesforce/core/testSetup';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 
 describe('end-to-end-test for local tracking', () => {
   let session: TestSession;

--- a/test/nuts/local/nonTopLevelIgnore.nut.ts
+++ b/test/nuts/local/nonTopLevelIgnore.nut.ts
@@ -9,7 +9,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import * as fs from 'graceful-fs';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 
 const registry = new RegistryAccess();
 

--- a/test/nuts/local/pkgDirMatching.nut.ts
+++ b/test/nuts/local/pkgDirMatching.nut.ts
@@ -9,7 +9,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import * as fs from 'graceful-fs';
 import { expect } from 'chai';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 
 describe('verifies exact match of pkgDirs', () => {
   const registry = new RegistryAccess();

--- a/test/nuts/local/relativePkgDirs.nut.ts
+++ b/test/nuts/local/relativePkgDirs.nut.ts
@@ -9,7 +9,7 @@ import { TestSession } from '@salesforce/cli-plugins-testkit';
 import * as fs from 'graceful-fs';
 import { expect } from 'chai';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
 
 describe('verifies behavior of relative pkgDirs', () => {
   let session: TestSession;

--- a/test/unit/localDetectMovedFiles.test.ts
+++ b/test/unit/localDetectMovedFiles.test.ts
@@ -12,7 +12,7 @@ import git from 'isomorphic-git';
 import { expect } from 'chai';
 import sinon = require('sinon');
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../src/shared/local/localShadowRepo';
 
 /* eslint-disable no-unused-expressions */
 

--- a/test/unit/localShadowRepo.test.ts
+++ b/test/unit/localShadowRepo.test.ts
@@ -12,7 +12,7 @@ import git from 'isomorphic-git';
 import { expect } from 'chai';
 import sinon = require('sinon');
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ShadowRepo } from '../../src/shared/localShadowRepo';
+import { ShadowRepo } from '../../src/shared/local/localShadowRepo';
 
 /* eslint-disable no-unused-expressions */
 
@@ -53,79 +53,5 @@ describe('localShadowRepo', () => {
     } finally {
       if (projectDir) await fs.promises.rm(projectDir, { recursive: true });
     }
-  });
-  it('respects SFDX_SOURCE_TRACKING_BATCH_SIZE env var', async () => {
-    expect(process.env.SFDX_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
-    process.env.SFDX_SOURCE_TRACKING_BATCH_SIZE = '1';
-    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'localShadowRepoTest'));
-
-    const shadowRepo: ShadowRepo = await ShadowRepo.getInstance({
-      orgId: '00D456789012345',
-      registry,
-      projectPath: projectDir,
-      packageDirs: [
-        {
-          name: 'dummy',
-          fullPath: 'dummy',
-          path: path.join(projectDir, 'force-app'),
-        },
-      ],
-    });
-    // private property maxFileAdd
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(shadowRepo.maxFileAdd).to.equal(1);
-    delete process.env.SFDX_SOURCE_TRACKING_BATCH_SIZE;
-    expect(process.env.SFDX_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
-  });
-
-  it('respects SF_SOURCE_TRACKING_BATCH_SIZE env var', async () => {
-    expect(process.env.SF_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
-    process.env.SF_SOURCE_TRACKING_BATCH_SIZE = '1';
-    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'localShadowRepoTest'));
-
-    const shadowRepo: ShadowRepo = await ShadowRepo.getInstance({
-      orgId: '00D456789012345',
-      registry,
-      projectPath: projectDir,
-      packageDirs: [
-        {
-          name: 'dummy',
-          fullPath: 'dummy',
-          path: path.join(projectDir, 'force-app'),
-        },
-      ],
-    });
-    // private property maxFileAdd
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(shadowRepo.maxFileAdd).to.equal(1);
-    delete process.env.SF_SOURCE_TRACKING_BATCH_SIZE;
-    expect(process.env.SF_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
-  });
-
-  it('respects undefined SF_SOURCE_TRACKING_BATCH_SIZE env var and uses default', async () => {
-    expect(process.env.SF_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
-    expect(process.env.SFDX_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
-    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'localShadowRepoTest'));
-
-    const shadowRepo: ShadowRepo = await ShadowRepo.getInstance({
-      orgId: '00D456789012345',
-      registry,
-      projectPath: projectDir,
-      packageDirs: [
-        {
-          name: 'dummy',
-          fullPath: 'dummy',
-          path: path.join(projectDir, 'force-app'),
-        },
-      ],
-    });
-    // private property maxFileAdd
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(shadowRepo.maxFileAdd).to.equal(os.type() === 'Windows_NT' ? 8000 : 15_000);
-    expect(process.env.SF_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
-    expect(process.env.SFDX_SOURCE_TRACKING_BATCH_SIZE).to.be.undefined;
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,6 +666,14 @@
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"
 
+"@salesforce/kit@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.2.tgz#270741c54c70969df19ef17f8979b4ef1fa664b2"
+  integrity sha512-si+ddvZDgx9q5czxAANuK5xhz3pv+KGspQy1wyia/7HDPKadA0QZkLTzUnO1Ju4Mux32CNHEb2y9lw9jj+eVTA==
+  dependencies:
+    "@salesforce/ts-types" "^2.0.9"
+    tslib "^2.6.2"
+
 "@salesforce/prettier-config@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.3.tgz#ba648d4886bb38adabe073dbea0b3a91b3753bb0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,14 +598,14 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.0"
 
-"@salesforce/core@^7.3.1", "@salesforce/core@^7.3.5", "@salesforce/core@^7.3.8":
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.8.tgz#8a646b5321f08c0fb4d22e2fa8b1d60b3a20df9b"
-  integrity sha512-VWhXHfjwjtC3pJWYp8wt5/fnNQ5tK61ovMG5eteXzVD2oFd7og1f6YjwuAzoYIZK7kYWWv7KJfGtCsPs7Zw+Ww==
+"@salesforce/core@^7.3.1", "@salesforce/core@^7.3.5", "@salesforce/core@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.9.tgz#8abe2b3e2393989d11e92b7a6b96043fc9d5b9c8"
+  integrity sha512-eJqDiA5b7wU50Ee/xjmGzSnHrNVJ8S77B7enfX30gm7gxU3i3M3QeBdiV6XAOPLSIL96DseofP6Tv6c+rljlKA==
   dependencies:
     "@jsforce/jsforce-node" "^3.2.0"
     "@salesforce/kit" "^3.1.1"
-    "@salesforce/schemas" "^1.7.0"
+    "@salesforce/schemas" "^1.9.0"
     "@salesforce/ts-types" "^2.0.9"
     ajv "^8.13.0"
     change-case "^4.1.2"
@@ -671,15 +671,15 @@
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.3.tgz#ba648d4886bb38adabe073dbea0b3a91b3753bb0"
   integrity sha512-hYOhoPTCSYMDYn+U1rlEk16PoBeAJPkrdg4/UtAzupM1mRRJOwEPMG1d7U8DxJFKuXW3DMEYWr2MwAIBDaHmFg==
 
-"@salesforce/schemas@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.7.0.tgz#b7e0af3ee414ae7160bce351c0184d77ccb98fe3"
-  integrity sha512-Z0PiCEV55khm0PG+DsnRYCjaDmacNe3HDmsoSm/CSyYvJJm+D5vvkHKN9/PKD/gaRe8XAU836yfamIYFblLINw==
+"@salesforce/schemas@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
+  integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
 
-"@salesforce/source-deploy-retrieve@^11.4.4":
-  version "11.4.4"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.4.4.tgz#c853e0888c6a5b64c4af3e705010ef1a6dac4c13"
-  integrity sha512-6dohRR9t6Aj2mbHzfYtbphxqxF83AwmAjkFFQPB6+Yn1ceVKmJjd0WY23fgWTTaTum+2pnw9XA35qwu4naBCVw==
+"@salesforce/source-deploy-retrieve@^11.6.2":
+  version "11.6.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.6.2.tgz#2d4faf3c00cc38dad0245f07a9b978131b845a5e"
+  integrity sha512-GEDTo4JCgisQt2hVyRY4Tu/ivEt2u9hJRzNn7A6ZDu668/0Ufq04YhdZfmSJePXAAtrtd9OqYfj8aJO5AOk1+g==
   dependencies:
     "@salesforce/core" "^7.3.5"
     "@salesforce/kit" "^3.1.1"
@@ -5178,16 +5178,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5246,14 +5237,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5770,7 +5754,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5783,15 +5767,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,12 +676,12 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
   integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
 
-"@salesforce/source-deploy-retrieve@^11.6.2":
-  version "11.6.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.6.2.tgz#2d4faf3c00cc38dad0245f07a9b978131b845a5e"
-  integrity sha512-GEDTo4JCgisQt2hVyRY4Tu/ivEt2u9hJRzNn7A6ZDu668/0Ufq04YhdZfmSJePXAAtrtd9OqYfj8aJO5AOk1+g==
+"@salesforce/source-deploy-retrieve@^11.6.3":
+  version "11.6.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.6.3.tgz#24ff55a17f8d7862b1467e40968707fedaa3e624"
+  integrity sha512-6h/KJV8cRfzLZ3aE6PP76oP1bz28zRxL9wtCx6yD+jz4GRdIxHNjNQhiKJJI9m2Z+npWl/sjth8aHB7rrSgSrg==
   dependencies:
-    "@salesforce/core" "^7.3.5"
+    "@salesforce/core" "^7.3.9"
     "@salesforce/kit" "^3.1.1"
     "@salesforce/ts-types" "^2.0.9"
     fast-levenshtein "^3.0.0"
@@ -5178,16 +5178,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5246,14 +5237,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5770,7 +5754,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5783,15 +5767,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What does this PR do?
- hash files using isogit to avoid walking files in trees outside of packageDirs.
- moveScale NUT creates a lot of local files
- reorganize code
- move some non-variable stuff (os, os/env dependent max file moves) in ShadowRepo to consts for all instances.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2880
@W-15840593@

### test perf

on exact code from `main`
    ✔ should show 0 files in git status after moving them (10703ms)

on code from main modified with 100_000 local non-project files, 
    ✔ should show 0 files in git status after moving them (17424ms)

this PR with 100_000 local non-project files, 
    ✔ should show 0 files in git status after moving them (12291ms)
