### PR TITLE
fix: support `SF_` env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@oclif/core": "^4.0.18",
-    "@salesforce/core": "^8.4.0",
+    "@salesforce/core": "8.5.2-dev.0",
     "@salesforce/kit": "^3.2.1",
     "@salesforce/source-deploy-retrieve": "^12.6.0",
     "@salesforce/ts-types": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oclif/core": "^4.0.18",
     "@salesforce/core": "^8.4.0",
     "@salesforce/kit": "^3.2.1",
-    "@salesforce/source-deploy-retrieve": "^12.5.1",
+    "@salesforce/source-deploy-retrieve": "^12.6.0",
     "@salesforce/ts-types": "^2.0.12",
     "fast-xml-parser": "^4.4.1",
     "graceful-fs": "^4.2.11",

--- a/src/shared/local/localShadowRepo.ts
+++ b/src/shared/local/localShadowRepo.ts
@@ -52,10 +52,7 @@ type CommitRequest = {
 
 /** do not try to add more than this many files at a time through isogit.  You'll hit EMFILE: too many open files even with graceful-fs */
 
-const MAX_FILE_ADD = envVars.getNumber(
-  'SF_SOURCE_TRACKING_BATCH_SIZE',
-  envVars.getNumber('SF_SOURCE_TRACKING_BATCH_SIZE', IS_WINDOWS ? 8000 : 15_000)
-);
+const MAX_FILE_ADD = envVars.getNumber('SFDX_SOURCE_TRACKING_BATCH_SIZE', IS_WINDOWS ? 8000 : 15_000);
 
 export class ShadowRepo {
   private static instanceMap = new Map<string, ShadowRepo>();

--- a/src/shared/local/localShadowRepo.ts
+++ b/src/shared/local/localShadowRepo.ts
@@ -8,7 +8,7 @@
 import path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'graceful-fs';
-import { NamedPackageDir, Lifecycle, Logger, SfError } from '@salesforce/core';
+import { NamedPackageDir, Lifecycle, Logger, SfError, envVars } from '@salesforce/core';
 import { env } from '@salesforce/kit';
 // @ts-expect-error isogit has both ESM and CJS exports but node16 module/resolution identifies it as ESM
 import git from 'isomorphic-git';
@@ -52,9 +52,9 @@ type CommitRequest = {
 
 /** do not try to add more than this many files at a time through isogit.  You'll hit EMFILE: too many open files even with graceful-fs */
 
-const MAX_FILE_ADD = env.getNumber(
+const MAX_FILE_ADD = envVars.getNumber(
   'SF_SOURCE_TRACKING_BATCH_SIZE',
-  env.getNumber('SFDX_SOURCE_TRACKING_BATCH_SIZE', IS_WINDOWS ? 8000 : 15_000)
+  envVars.getNumber('SF_SOURCE_TRACKING_BATCH_SIZE', IS_WINDOWS ? 8000 : 15_000)
 );
 
 export class ShadowRepo {

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -572,7 +572,7 @@ const readFileContents = async (filePath: string): Promise<Contents | Record<str
 export const calculateTimeout =
   (logger: PinoLogger) =>
   (memberCount: number): Duration => {
-    const overriddenTimeout = envVars.getNumber('SF_SOURCE_MEMBER_POLLING_TIMEOUT', 0);
+    const overriddenTimeout = envVars.getNumber('SFDX_SOURCE_MEMBER_POLLING_TIMEOUT', 0);
     if (overriddenTimeout > 0) {
       logger.debug(`Overriding SourceMember polling timeout to ${overriddenTimeout}`);
       return Duration.seconds(overriddenTimeout);

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -237,8 +237,8 @@ export class RemoteSourceTrackingService {
    * @param pollingTimeout maximum amount of time in seconds to poll for SourceMembers
    */
   public async pollForSourceTracking(expectedMembers: RemoteSyncInput[]): Promise<void> {
-    if (envVars.getBoolean('SF_DISABLE_SOURCE_MEMBER_POLLING', false)) {
-      this.logger.warn('Not polling for SourceMembers since SFDX_DISABLE_SOURCE_MEMBER_POLLING = true.');
+    if (envVars.getBoolean('SFDX_DISABLE_SOURCE_MEMBER_POLLING', false)) {
+      this.logger.warn('Not polling for SourceMembers since SF_DISABLE_SOURCE_MEMBER_POLLING = true.');
       return;
     }
 

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -9,8 +9,8 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { EOL } from 'node:os';
 import { retryDecorator, NotRetryableError } from 'ts-retry-promise';
-import { Logger, Org, Messages, Lifecycle, SfError, Connection, lockInit } from '@salesforce/core';
-import { env, Duration, parseJsonMap } from '@salesforce/kit';
+import { Logger, Org, Messages, Lifecycle, SfError, Connection, envVars, lockInit } from '@salesforce/core';
+import { Duration, parseJsonMap } from '@salesforce/kit';
 import { isString } from '@salesforce/ts-types';
 import {
   ChangeResult,
@@ -40,7 +40,7 @@ const FILENAME = 'maxRevision.json';
  */
 const POLLING_DELAY_MS = 1000;
 const CONSECUTIVE_EMPTY_POLLING_RESULT_LIMIT =
-  (env.getNumber('SFDX_SOURCE_MEMBER_POLLING_TIMEOUT') ?? 120) / Duration.milliseconds(POLLING_DELAY_MS).seconds;
+  (envVars.getNumber('SF_SOURCE_MEMBER_POLLING_TIMEOUT') ?? 120) / Duration.milliseconds(POLLING_DELAY_MS).seconds;
 
 /** Options for RemoteSourceTrackingService.getInstance */
 export type RemoteSourceTrackingServiceOptions = {
@@ -237,7 +237,7 @@ export class RemoteSourceTrackingService {
    * @param pollingTimeout maximum amount of time in seconds to poll for SourceMembers
    */
   public async pollForSourceTracking(expectedMembers: RemoteSyncInput[]): Promise<void> {
-    if (env.getBoolean('SFDX_DISABLE_SOURCE_MEMBER_POLLING', false)) {
+    if (envVars.getBoolean('SF_DISABLE_SOURCE_MEMBER_POLLING', false)) {
       this.logger.warn('Not polling for SourceMembers since SFDX_DISABLE_SOURCE_MEMBER_POLLING = true.');
       return;
     }
@@ -572,7 +572,7 @@ const readFileContents = async (filePath: string): Promise<Contents | Record<str
 export const calculateTimeout =
   (logger: PinoLogger) =>
   (memberCount: number): Duration => {
-    const overriddenTimeout = env.getNumber('SFDX_SOURCE_MEMBER_POLLING_TIMEOUT', 0);
+    const overriddenTimeout = envVars.getNumber('SF_SOURCE_MEMBER_POLLING_TIMEOUT', 0);
     if (overriddenTimeout > 0) {
       logger.debug(`Overriding SourceMember polling timeout to ${overriddenTimeout}`);
       return Duration.seconds(overriddenTimeout);

--- a/test/unit/remoteSourceTracking.test.ts
+++ b/test/unit/remoteSourceTracking.test.ts
@@ -11,9 +11,8 @@ import { writeFile, mkdir, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { sep, dirname } from 'node:path';
 import { MockTestOrgData, instantiateContext, stubContext, restoreContext } from '@salesforce/core/testSetup';
-import { Logger, Messages, Org } from '@salesforce/core';
+import { envVars, Logger, Messages, Org } from '@salesforce/core';
 // eslint-disable-next-line no-restricted-imports
-import * as kit from '@salesforce/kit';
 import { expect } from 'chai';
 import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
 import { RemoteSourceTrackingService, calculateTimeout, Contents } from '../../src/shared/remoteSourceTrackingService';
@@ -469,7 +468,7 @@ describe('remoteSourceTrackingService', () => {
       });
     });
     it('should not poll when SFDX_DISABLE_SOURCE_MEMBER_POLLING=true', async () => {
-      const getBooleanStub = $$.SANDBOX.stub(kit.env, 'getBoolean').callsFake(() => true);
+      const getBooleanStub = $$.SANDBOX.stub(envVars, 'getBoolean').callsFake(() => true);
 
       // @ts-ignore
       const trackSpy = $$.SANDBOX.stub(remoteSourceTrackingService, 'trackSourceMembers');
@@ -512,7 +511,7 @@ describe('remoteSourceTrackingService', () => {
 
       it('should stop if SFDX_SOURCE_MEMBER_POLLING_TIMEOUT is exceeded', async () => {
         // @ts-ignore
-        $$.SANDBOX.stub(kit.env, 'getString').callsFake(() => '3');
+        $$.SANDBOX.stub(envVars, 'getString').callsFake(() => '3');
         // @ts-ignore
         const queryStub = $$.SANDBOX.stub(remoteSourceTrackingService, 'querySourceMembersFrom').resolves([]);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
     "skipLibCheck": true,
     "plugins": [{ "transform": "@salesforce/core/messageTransformer", "import": "messageTransformer" }],
     "moduleResolution": "Node16",
-    "module": "Node16"
+    "module": "Node16",
+    "paths": {
+      "@salesforce/core": ["./node_modules/@salesforce/core"]
+    }
   },
   "include": ["src/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,6 +546,30 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
+"@salesforce/core@8.5.2-dev.0":
+  version "8.5.2-dev.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.5.2-dev.0.tgz#052869d7cac7e7aed655371b35f8da4893af36d8"
+  integrity sha512-XOYDx5DvXGhCRMhKBNzpZdpLta993tru1t+Lps/ipc4YMeYvjpXuFUdDU22sYCsMOyHgGgB8WkBYkr6SxU71dA==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.4.0"
+    "@salesforce/kit" "^3.1.6"
+    "@salesforce/schemas" "^1.9.0"
+    "@salesforce/ts-types" "^2.0.10"
+    ajv "^8.17.1"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^9.3.2"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.2.2"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.3"
+    ts-retry-promise "^0.8.1"
+
 "@salesforce/core@^8.3.0", "@salesforce/core@^8.4.0":
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.4.0.tgz#d2ddfe07994c42b1e917e581e9cf47ad27b97a93"
@@ -1340,19 +1364,12 @@ brace-expansion@^4.0.0:
   dependencies:
     balanced-match "^3.0.0"
 
-braces@^3.0.3:
+braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
-
-braces@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
-  dependencies:
-    fill-range "^7.0.1"
 
 browser-stdout@^1.3.1:
   version "1.3.1"
@@ -2500,14 +2517,7 @@ filelist@^1.0.4:
   dependencies:
     minimatch "^5.0.1"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
-  dependencies:
-    to-regex-range "^5.0.1"
-
-fill-range@^7.1.1:
+fill-range@^7.0.1, fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,10 +624,10 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
   integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
 
-"@salesforce/source-deploy-retrieve@^12.5.1":
-  version "12.5.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.5.1.tgz#55e915201b2c9320b9662b2c8500a191c8770ecf"
-  integrity sha512-jakBWFSIb8oZlUAf0QKHXaeFA/KuTQZwaKZVevdwaiuy43lJHzVVrSRfcNv/kjXxmg0oq5TAI8vUo2CC5Hq04A==
+"@salesforce/source-deploy-retrieve@^12.6.0":
+  version "12.6.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.6.0.tgz#0d2961fb2befeac0431fe8f6a70f439bc049fcea"
+  integrity sha512-gowMwjG93a8Bd5N05o46Z46TSsHZMeZXV3rQwMP3LXDnIhvSx3vxHJMzk0KKMOatfQFF2t+YI/6MR+47KWSblw==
   dependencies:
     "@salesforce/core" "^8.4.0"
     "@salesforce/kit" "^3.2.1"
@@ -637,6 +637,7 @@
     got "^11.8.6"
     graceful-fs "^4.2.11"
     ignore "^5.3.2"
+    isbinaryfile "^5.0.2"
     jszip "^3.10.1"
     mime "2.6.0"
     minimatch "^9.0.5"
@@ -3307,6 +3308,11 @@ isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
+isbinaryfile@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-5.0.2.tgz#fe6e4dfe2e34e947ffa240c113444876ba393ae0"
+  integrity sha512-GvcjojwonMjWbTkfMpnVHVqXW/wKMYDfEpY94/8zy8HFMOqb/VL6oeONq9v87q4ttVlaTLnGXnJD4B5B1OTGIg==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -5146,16 +5152,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5214,14 +5211,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5721,7 +5711,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5734,15 +5724,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What does this PR do?

DEPENDS ON: https://github.com/forcedotcom/sfdx-core/pull/1132

The following env vars were being resolved via `@salesforce/kit` instead of sfdx-core:

`SFDX_SOURCE_TRACKING_BATCH_SIZE`

it's `SF_` version worked by trying to read it first and falling back to the `SFDX_` one here:
 https://github.com/forcedotcom/source-tracking/blob/236a0c61b81758a710a97a14fa9805ba4a8560cf/src/shared/local/localShadowRepo.ts#L55

`SFDX_SOURCE_MEMBER_POLLING_TIMEOUT`

never supported its `SF_` version documented here:
https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_env_variables.htm

This PR makes source-tracking read these via sfdx-core (also added support there in the linked PR above).
Both `SFDX_` and `SF_` should be supported now, no breaking changes.

### What issues does this PR fix or reference?
@[W-16628512](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020JhbgYAC/view)@