### PR TITLE
fix: resolve fullname correctly for EmailTemplateFolder

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oclif/core": "^4.0.20",
     "@salesforce/core": "^8.5.4",
     "@salesforce/kit": "^3.2.1",
-    "@salesforce/source-deploy-retrieve": "^12.6.0",
+    "@salesforce/source-deploy-retrieve": "^12.7.1",
     "@salesforce/ts-types": "^2.0.12",
     "fast-xml-parser": "^4.5.0",
     "graceful-fs": "^4.2.11",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "@oclif/core": "^4.0.20",
-    "@salesforce/core": "^8.5.4",
-    "@salesforce/kit": "^3.2.1",
+    "@salesforce/core": "^8.6.1",
+    "@salesforce/kit": "^3.2.3",
     "@salesforce/source-deploy-retrieve": "^12.7.1",
     "@salesforce/ts-types": "^2.0.12",
     "fast-xml-parser": "^4.5.0",

--- a/src/shared/remoteSourceTrackingService.ts
+++ b/src/shared/remoteSourceTrackingService.ts
@@ -509,7 +509,9 @@ export const remoteChangeElementToChangeResult = (rce: RemoteChangeElement): Cha
   ...rce,
   ...(mappingsForSourceMemberTypesToMetadataType.has(rce.type)
     ? {
-        name: rce.name.split('/')[0],
+        // SNOWFLAKE: EmailTemplateFolder is treated as an alias for EmailFolder so it has a mapping.
+        // The name must be handled differently than with bundle types.
+        name: rce.type === 'EmailTemplateFolder' ? rce.name : rce.name.split('/')[0],
         type: mappingsForSourceMemberTypesToMetadataType.get(rce.type),
       }
     : {}),

--- a/test/unit/remoteSourceTracking.test.ts
+++ b/test/unit/remoteSourceTracking.test.ts
@@ -14,8 +14,13 @@ import { MockTestOrgData, instantiateContext, stubContext, restoreContext } from
 import { EnvVars, envVars, Logger, Messages, Org } from '@salesforce/core';
 import { expect } from 'chai';
 import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
-import { RemoteSourceTrackingService, calculateTimeout, Contents } from '../../src/shared/remoteSourceTrackingService';
-import { RemoteSyncInput, SourceMember, MemberRevision } from '../../src/shared/types';
+import {
+  RemoteSourceTrackingService,
+  calculateTimeout,
+  Contents,
+  remoteChangeElementToChangeResult,
+} from '../../src/shared/remoteSourceTrackingService';
+import { RemoteSyncInput, SourceMember, MemberRevision, RemoteChangeElement } from '../../src/shared/types';
 import * as mocks from '../../src/shared/remoteSourceTrackingService';
 
 Messages.importMessagesDirectory(__dirname);
@@ -92,6 +97,42 @@ describe('remoteSourceTrackingService', () => {
     remoteSourceTrackingService = await RemoteSourceTrackingService.getInstance({
       org,
       projectPath: await $$.localPathRetriever($$.id),
+    });
+
+    describe('remoteChangeElementToChangeResult()', () => {
+      it('should return correct ChangeResult for EmailTemplateFolder', () => {
+        const rce: RemoteChangeElement = {
+          name: 'level1/level2/level3',
+          type: 'EmailTemplateFolder',
+          deleted: false,
+          modified: true,
+        };
+        const changeResult = remoteChangeElementToChangeResult(rce);
+        expect(changeResult).to.deep.equal({
+          origin: 'remote',
+          name: 'level1/level2/level3',
+          type: 'EmailFolder',
+          deleted: false,
+          modified: true,
+        });
+      });
+
+      it('should return correct ChangeResult for LightningComponentResource', () => {
+        const rce: RemoteChangeElement = {
+          name: 'fooLWC/bar',
+          type: 'LightningComponentResource',
+          deleted: false,
+          modified: true,
+        };
+        const changeResult = remoteChangeElementToChangeResult(rce);
+        expect(changeResult).to.deep.equal({
+          origin: 'remote',
+          name: 'fooLWC',
+          type: 'LightningComponentBundle',
+          deleted: false,
+          modified: true,
+        });
+      });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,7 +546,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.5.1", "@salesforce/core@^8.5.2", "@salesforce/core@^8.5.4":
+"@salesforce/core@^8.5.1", "@salesforce/core@^8.5.4":
   version "8.5.4"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.5.4.tgz#1cdd669462d2c2859b72135d1138a1b790b1fbcc"
   integrity sha512-dO8tzFxq811qNPeKPPO2OA2KPYW5rO0YRinW/+7zmRJW3EtNpe93dsQVGwBSAAYrSbYeBwiKdliNqNTN7tKJ0A==
@@ -564,6 +564,30 @@
     jsonwebtoken "9.0.2"
     jszip "3.10.1"
     pino "^9.3.2"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.2.2"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.3"
+    ts-retry-promise "^0.8.1"
+
+"@salesforce/core@^8.5.7":
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.6.1.tgz#180c489447190632cf48364a077510989fc1dea2"
+  integrity sha512-bOS6YIjk3IFzFtZcQXUIbJQ740Gh6EyzlcvoBpDpFA5eaz5ZrS0dO1e0rU6Gn4V1FZkvt84gQXA5G1M8tTNKVw==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.4.1"
+    "@salesforce/kit" "^3.2.2"
+    "@salesforce/schemas" "^1.9.0"
+    "@salesforce/ts-types" "^2.0.10"
+    ajv "^8.17.1"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^9.4.0"
     pino-abstract-transport "^1.2.0"
     pino-pretty "^11.2.2"
     proper-lockfile "^4.1.2"
@@ -624,16 +648,16 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
   integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
 
-"@salesforce/source-deploy-retrieve@^12.6.0":
-  version "12.6.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.6.2.tgz#eb9ab120621c80a404b9ec45a2b102f3f2befbff"
-  integrity sha512-ucEt/CyzL4ovMc2cYREk4meQzKe6/FlY/D09yLmOQ118Oec680ehEhJ1kGRE/I7HTzfgQP3Fy2GzhQX1bOYC5Q==
+"@salesforce/source-deploy-retrieve@^12.7.1":
+  version "12.7.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.7.1.tgz#5e828fb721edac136d0903624d82cb5f9e197f21"
+  integrity sha512-duFgp76CHA8coLEkl9QYmJJmJrHHiU4EtRkBv3hP0H0lTDaMdwCjfxAexGLxT2PCRsE5fbZgwJg+wYFLJHZkIw==
   dependencies:
-    "@salesforce/core" "^8.5.2"
+    "@salesforce/core" "^8.5.7"
     "@salesforce/kit" "^3.2.2"
     "@salesforce/ts-types" "^2.0.12"
     fast-levenshtein "^3.0.0"
-    fast-xml-parser "^4.4.1"
+    fast-xml-parser "^4.5.0"
     got "^11.8.6"
     graceful-fs "^4.2.11"
     ignore "^5.3.2"
@@ -2441,7 +2465,7 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.1.tgz#cddd2eecfc83a71c1be2cc2ef2061331be8a7134"
   integrity sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==
 
-fast-xml-parser@^4.4.1, fast-xml-parser@^4.5.0:
+fast-xml-parser@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz#2882b7d01a6825dfdf909638f2de0256351def37"
   integrity sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==
@@ -4462,6 +4486,23 @@ pino@^9.3.2:
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/pino/-/pino-9.3.2.tgz#a530d6d28f1d954b6f54416a218cbb616f52f901"
   integrity sha512-WtARBjgZ7LNEkrGWxMBN/jvlFiE17LTbBoH0konmBU684Kd0uIiDwBXlcTCW7iJnA6HfIKwUssS/2AC6cDEanw==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.1.1"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^1.2.0"
+    pino-std-serializers "^7.0.0"
+    process-warning "^4.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^4.0.1"
+    thread-stream "^3.0.0"
+
+pino@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-9.4.0.tgz#e4600ff199efc744856a5b3b71c53e38998eae5a"
+  integrity sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==
   dependencies:
     atomic-sleep "^1.0.0"
     fast-redact "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,7 +546,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.5.1", "@salesforce/core@^8.5.4":
+"@salesforce/core@^8.5.1":
   version "8.5.4"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.5.4.tgz#1cdd669462d2c2859b72135d1138a1b790b1fbcc"
   integrity sha512-dO8tzFxq811qNPeKPPO2OA2KPYW5rO0YRinW/+7zmRJW3EtNpe93dsQVGwBSAAYrSbYeBwiKdliNqNTN7tKJ0A==
@@ -570,7 +570,7 @@
     semver "^7.6.3"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.5.7":
+"@salesforce/core@^8.5.7", "@salesforce/core@^8.6.1":
   version "8.6.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.6.1.tgz#180c489447190632cf48364a077510989fc1dea2"
   integrity sha512-bOS6YIjk3IFzFtZcQXUIbJQ740Gh6EyzlcvoBpDpFA5eaz5ZrS0dO1e0rU6Gn4V1FZkvt84gQXA5G1M8tTNKVw==
@@ -635,6 +635,13 @@
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.2.2.tgz#2a0db472116a416cb12b510d546cb35a582d619a"
   integrity sha512-Qh+Jx65LKR3BlH+bxNBbvI4+/+/igAJ9x2iEDM3tHb3B2JCEnssPP0lw+K/zWHsdtk+OorBiKpHaC6RrjW+9fw==
+  dependencies:
+    "@salesforce/ts-types" "^2.0.12"
+
+"@salesforce/kit@^3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.2.3.tgz#a7293c384ef6133191fe3590e604e3896fdecf4a"
+  integrity sha512-X8rZouLt06dxRkn+uYTwywWDS/NqZ783AyomGqgtWdUxF61EOJvu0ehtcYeutx9Ng08uuZ+s6wNvWiDsdhUcPg==
   dependencies:
     "@salesforce/ts-types" "^2.0.12"
 


### PR DESCRIPTION
### What does this PR do?
Some SourceMember types are mapped to different metadata types in SDR.  EmailTemplateFolder is one of them; it maps to EmailFolder which is treated as an alias in SDR.  The FullName parsing was updated to use the entire FullName rather than following a substring pattern for other mapped types like Aura and LWC.

### What issues does this PR fix or reference?
@W-16618249@
https://github.com/forcedotcom/cli/issues/2902