### PR TITLE
perf: early exit for pathIsInfolder (19% faster)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
   },
   "dependencies": {
     "@oclif/core": "^4.4.0",
-    "@salesforce/core": "^8.15.0",
+    "@salesforce/core": "^8.18.1",
     "@salesforce/kit": "^3.2.3",
-    "@salesforce/source-deploy-retrieve": "^12.20.1",
+    "@salesforce/source-deploy-retrieve": "^12.21.1",
     "@salesforce/ts-types": "^2.0.12",
     "fast-xml-parser": "^4.5.3",
     "graceful-fs": "^4.2.11",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@oclif/core": "^4.4.0",
     "@salesforce/core": "^8.18.1",
     "@salesforce/kit": "^3.2.3",
-    "@salesforce/source-deploy-retrieve": "^12.21.1",
+    "@salesforce/source-deploy-retrieve": "^12.21.4",
     "@salesforce/ts-types": "^2.0.12",
     "fast-xml-parser": "^4.5.3",
     "graceful-fs": "^4.2.11",

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -59,12 +59,13 @@ export const pathIsInFolder =
 
     // use sep to ensure a folder like foo will not match a filePath like foo-bar
     // comparing foo/ to foo-bar/ ensure this.
-    if (!(filePath + sep).includes(folder + sep)) {
+    const normalizedFolderPath = normalize(`${folder}${sep}`);
+    if (!`${sep}${filePath}${sep}`.includes(normalizedFolderPath)) {
       return false;
     }
 
     const filePathParts = normalize(filePath).split(sep).filter(nonEmptyStringFilter);
-    return normalize(folder)
+    return normalizedFolderPath
       .split(sep)
       .filter(nonEmptyStringFilter)
       .every((part, index) => part === filePathParts[index]);

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -57,14 +57,14 @@ export const pathIsInFolder =
       return true;
     }
 
-    const normalizedfilePath = normalize(sep + filePath + sep);
-    const normalizedfolderPath = normalize(sep + folder + sep);
-    if (!normalizedfilePath.startsWith(normalizedfolderPath)) {
+    // use sep to ensure a folder like foo will not match a filePath like foo-bar
+    // comparing foo/ to foo-bar/ ensure this.
+    if (!(filePath + sep).includes(folder + sep)) {
       return false;
     }
 
-    const filePathParts = normalizedfilePath.split(sep).filter(nonEmptyStringFilter);
-    return normalizedfolderPath
+    const filePathParts = normalize(filePath).split(sep).filter(nonEmptyStringFilter);
+    return normalize(folder)
       .split(sep)
       .filter(nonEmptyStringFilter)
       .every((part, index) => part === filePathParts[index]);

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -43,11 +43,17 @@ export const excludeLwcLocalOnlyTest = (filePath: string): boolean =>
 export const pathIsInFolder =
   (folder: string) =>
   (filePath: string): boolean => {
-    const biggerStringParts = normalize(filePath).split(sep).filter(nonEmptyStringFilter);
-    return normalize(folder)
-      .split(sep)
-      .filter(nonEmptyStringFilter)
-      .every((part, index) => part === biggerStringParts[index]);
+    if (folder === filePath) {
+      return true;
+    }
+
+    if (!filePath.startsWith(folder)) {
+      return false;
+    }
+
+    const filePathParts = normalize(filePath).split(sep).filter(nonEmptyStringFilter);
+    const folderParts = normalize(folder).split(sep).filter(nonEmptyStringFilter);
+    return folderParts.every((part, index) => part === filePathParts[index]);
   };
 
 /** just like pathIsInFolder but with the parameter order reversed for iterating a single file against an array of folders */

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -47,13 +47,17 @@ export const pathIsInFolder =
       return true;
     }
 
-    if (!filePath.startsWith(folder)) {
+    const normalizedfilePath = normalize(sep + filePath + sep);
+    const normalizedfolderPath = normalize(sep + folder + sep);
+    if (!normalizedfilePath.startsWith(normalizedfolderPath)) {
       return false;
     }
 
-    const filePathParts = normalize(filePath).split(sep).filter(nonEmptyStringFilter);
-    const folderParts = normalize(folder).split(sep).filter(nonEmptyStringFilter);
-    return folderParts.every((part, index) => part === filePathParts[index]);
+    const filePathParts = normalizedfilePath.split(sep).filter(nonEmptyStringFilter);
+    return normalizedfolderPath
+      .split(sep)
+      .filter(nonEmptyStringFilter)
+      .every((part, index) => part === filePathParts[index]);
   };
 
 /** just like pathIsInFolder but with the parameter order reversed for iterating a single file against an array of folders */

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -60,11 +60,12 @@ export const pathIsInFolder =
     // use sep to ensure a folder like foo will not match a filePath like foo-bar
     // comparing foo/ to foo-bar/ ensure this.
     const normalizedFolderPath = normalize(`${folder}${sep}`);
-    if (!`${sep}${filePath}${sep}`.includes(normalizedFolderPath)) {
-      return false;
+    const normalizedFilePath = normalize(`${filePath}${sep}`);
+    if (normalizedFilePath.startsWith(normalizedFolderPath)) {
+      return true;
     }
 
-    const filePathParts = normalize(filePath).split(sep).filter(nonEmptyStringFilter);
+    const filePathParts = normalizedFilePath.split(sep).filter(nonEmptyStringFilter);
     return normalizedFolderPath
       .split(sep)
       .filter(nonEmptyStringFilter)

--- a/src/shared/localComponentSetArray.ts
+++ b/src/shared/localComponentSetArray.ts
@@ -34,11 +34,14 @@ export const getGroupedFiles = (input: GroupedFileInput, byPackageDir = false): 
   );
 
 const getSequential = ({ packageDirs, nonDeletes, deletes }: GroupedFileInput): GroupedFile[] =>
-  packageDirs.map((pkgDir) => ({
-    path: pkgDir.name,
-    nonDeletes: nonDeletes.filter(pathIsInFolder(pkgDir.name)),
-    deletes: deletes.filter(pathIsInFolder(pkgDir.name)),
-  }));
+  packageDirs.map((pkgDir) => {
+    const { name } = pkgDir;
+    return {
+      path: name,
+      nonDeletes: nonDeletes.filter(pathIsInFolder(name)),
+      deletes: deletes.filter(pathIsInFolder(name)),
+    };
+  });
 
 const getNonSequential = ({
   packageDirs,

--- a/src/shared/localComponentSetArray.ts
+++ b/src/shared/localComponentSetArray.ts
@@ -33,15 +33,37 @@ export const getGroupedFiles = (input: GroupedFileInput, byPackageDir = false): 
     (group) => group.deletes.length || group.nonDeletes.length
   );
 
-const getSequential = ({ packageDirs, nonDeletes, deletes }: GroupedFileInput): GroupedFile[] =>
-  packageDirs.map((pkgDir) => {
+const getSequential = ({ packageDirs, nonDeletes, deletes }: GroupedFileInput): GroupedFile[] => {
+  const nonDeletesByPkgDir = groupByPkgDir(nonDeletes, packageDirs);
+  const deletesByPkgDir = groupByPkgDir(deletes, packageDirs);
+  return packageDirs.map((pkgDir) => {
     const { name } = pkgDir;
     return {
       path: name,
-      nonDeletes: nonDeletes.filter(pathIsInFolder(name)),
-      deletes: deletes.filter(pathIsInFolder(name)),
+      nonDeletes: nonDeletesByPkgDir.get(name) ?? [],
+      deletes: deletesByPkgDir.get(name) ?? [],
     };
   });
+};
+
+const groupByPkgDir = (filePaths: string[], pkgDirs: NamedPackageDir[]): Map<string, string[]> => {
+  const groups = new Map<string, string[]>();
+  pkgDirs.forEach((pkgDir) => {
+    groups.set(pkgDir.name, []);
+  });
+
+  filePaths.forEach((filePath) => {
+    pkgDirs.forEach((pkgDir) => {
+      const { name } = pkgDir;
+      if (pathIsInFolder(name)(filePath)) {
+        groups.get(name)?.push(filePath);
+        return;
+      }
+    });
+  });
+
+  return groups;
+};
 
 const getNonSequential = ({
   packageDirs,

--- a/test/unit/localComponentSetArray.test.ts
+++ b/test/unit/localComponentSetArray.test.ts
@@ -111,4 +111,51 @@ describe('groupings', () => {
       ).to.have.length(0);
     });
   });
+
+  it('handles empty packageDirs gracefully', () => {
+    const result = getGroupedFiles({
+      packageDirs: [],
+      nonDeletes: ['one/file1.xml'],
+      deletes: ['one/delete.xml'],
+    });
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it('handles mixed valid and invalid paths in nonDeletes and deletes', () => {
+    const result = getGroupedFiles(
+      {
+        packageDirs,
+        nonDeletes: ['one/file1.xml', 'invalid/file.xml'],
+        deletes: ['two/delete.xml', 'invalid/delete.xml'],
+      },
+      true
+    );
+
+    expect(result).to.deep.equal([
+      {
+        path: 'one',
+        nonDeletes: ['one/file1.xml'],
+        deletes: [],
+      },
+      {
+        path: 'two',
+        nonDeletes: [],
+        deletes: ['two/delete.xml'],
+      },
+    ]);
+  });
+
+  it('handles sequential flag as false with empty nonDeletes and deletes', () => {
+    const result = getGroupedFiles(
+      {
+        packageDirs,
+        nonDeletes: [],
+        deletes: [],
+      },
+      false
+    );
+
+    expect(result).to.deep.equal([]);
+  });
 });

--- a/test/unit/pathIsInFolder.test.ts
+++ b/test/unit/pathIsInFolder.test.ts
@@ -34,4 +34,40 @@ describe('pathIsInFolder', () => {
       true
     );
   });
+
+  it('returns false for completely unrelated paths', () => {
+    expect(pathIsInFolder(normalize('/foo/bar'))(normalize('/baz/qux'))).to.equal(false);
+  });
+
+  it('handles relative paths correctly', () => {
+    expect(pathIsInFolder('foo/bar')(normalize('foo/bar/baz'))).to.equal(true);
+    expect(pathIsInFolder('foo/bar')(normalize('foo/baz'))).to.equal(false);
+  });
+
+  it('handles empty folder path gracefully', () => {
+    expect(pathIsInFolder('')(normalize('/foo/bar'))).to.equal(false);
+  });
+
+  it('handles empty target path gracefully', () => {
+    expect(pathIsInFolder(normalize('/foo/bar'))('')).to.equal(false);
+  });
+
+  it('handles both paths being empty', () => {
+    expect(pathIsInFolder('')('')).to.equal(false);
+  });
+
+  it('handles paths with trailing slashes', () => {
+    expect(pathIsInFolder(normalize('/foo/bar/'))(normalize('/foo/bar/baz'))).to.equal(true);
+    expect(pathIsInFolder(normalize('/foo/bar/'))(normalize('/foo/bar'))).to.equal(true);
+    expect(pathIsInFolder(normalize('/foo/bar/'))(normalize('/foo/bar/baz/'))).to.equal(true);
+    expect(pathIsInFolder(normalize('/foo/bar/'))(normalize('/foo/bar/'))).to.equal(true);
+  });
+
+  it('handles paths with mixed separators', () => {
+    expect(pathIsInFolder(normalize('/foo\\bar'))(normalize('/foo/bar/baz'))).to.equal(true);
+  });
+
+  it('handles exact paths', () => {
+    expect(pathIsInFolder(normalize('/foo/bar'))(normalize('/foo/bar'))).to.equal(true);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -668,7 +668,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.12.0", "@salesforce/core@^8.14.0", "@salesforce/core@^8.8.0":
+"@salesforce/core@^8.14.0", "@salesforce/core@^8.8.0":
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.15.0.tgz#95d337a7a219c2d305117c9f5594617784a8642f"
   integrity sha512-vTobdBQ7JRlApUDezUAVlC7O7VUk1e+9AM8+TZIVnj2Glub7E5vtwTJRDT48MJ/wWjdhH+9MFfUi2GPHymHmrQ==
@@ -770,12 +770,12 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
   integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
 
-"@salesforce/source-deploy-retrieve@^12.21.1":
-  version "12.21.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.21.1.tgz#081ea10b86b1af3c222d9dea3ac3774bdb477954"
-  integrity sha512-VC6sAaLH04z1znJh7f8ftlUTDEzzUFzpaau8kIVjZW7Iq4xSnRORmxlh941C2KSTPRR454ZbnxuWC5czcn5Bcg==
+"@salesforce/source-deploy-retrieve@^12.21.4":
+  version "12.21.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.21.4.tgz#dee92e9ad1feb7863f713e3b959a51a998f19279"
+  integrity sha512-ree+qZKUglNb1a80msPUzf4xH84sRze/m62X/FL5kCuCp28qEW/1qh8fjlmCpNFqEp92uwNkM6qKJ/GKr/Mtrw==
   dependencies:
-    "@salesforce/core" "^8.12.0"
+    "@salesforce/core" "^8.18.1"
     "@salesforce/kit" "^3.2.3"
     "@salesforce/ts-types" "^2.0.12"
     "@salesforce/types" "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -581,6 +581,22 @@
     node-fetch "^2.6.1"
     xml2js "^0.6.2"
 
+"@jsforce/jsforce-node@^3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.9.1.tgz#503bcee3b511b2768abb090b8c8af508c2412244"
+  integrity sha512-tHG9Wozb9tQMiOyKz4MgcSK0XEDdER+dUm42o7qUaokwqC+IPmjgptx0PNTO75U1nqgW6yX6M5Qq1thhj7KMCA==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.4.4"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    https-proxy-agent "^5.0.0"
+    multistream "^3.1.0"
+    node-fetch "^2.6.1"
+    xml2js "^0.6.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -652,12 +668,36 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.12.0", "@salesforce/core@^8.14.0", "@salesforce/core@^8.15.0", "@salesforce/core@^8.8.0":
+"@salesforce/core@^8.12.0", "@salesforce/core@^8.14.0", "@salesforce/core@^8.8.0":
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.15.0.tgz#95d337a7a219c2d305117c9f5594617784a8642f"
   integrity sha512-vTobdBQ7JRlApUDezUAVlC7O7VUk1e+9AM8+TZIVnj2Glub7E5vtwTJRDT48MJ/wWjdhH+9MFfUi2GPHymHmrQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.8.2"
+    "@salesforce/kit" "^3.2.2"
+    "@salesforce/schemas" "^1.9.0"
+    "@salesforce/ts-types" "^2.0.10"
+    ajv "^8.17.1"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^9.7.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.3.0"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.3"
+    ts-retry-promise "^0.8.1"
+
+"@salesforce/core@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.18.1.tgz#4a790f9479339f45e42799d9ef7a1428d49b6ba1"
+  integrity sha512-RkG9Ye5TdsIQz4KLUHvDpVjbrTeeRmw5KUJIHRyMGAOjKB8wr2jvgXyZm7GD0epIW5ILsyKQQWWOa1uqsfVycA==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.9.1"
     "@salesforce/kit" "^3.2.2"
     "@salesforce/schemas" "^1.9.0"
     "@salesforce/ts-types" "^2.0.10"
@@ -730,10 +770,10 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
   integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
 
-"@salesforce/source-deploy-retrieve@^12.20.1":
-  version "12.20.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.20.1.tgz#7514d98bd5a54e7a6b992cdb30305eef8288312f"
-  integrity sha512-pCGTgR90MRcpCS7WswMd7CHAgqK6DBssLuu+hL5KMiuthgfFjO8XNTGeHqZBc4xTYYzxm8h5vlN8aqElI4ppXA==
+"@salesforce/source-deploy-retrieve@^12.21.1":
+  version "12.21.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.21.1.tgz#081ea10b86b1af3c222d9dea3ac3774bdb477954"
+  integrity sha512-VC6sAaLH04z1znJh7f8ftlUTDEzzUFzpaau8kIVjZW7Iq4xSnRORmxlh941C2KSTPRR454ZbnxuWC5czcn5Bcg==
   dependencies:
     "@salesforce/core" "^8.12.0"
     "@salesforce/kit" "^3.2.3"


### PR DESCRIPTION
Clone of https://github.com/forcedotcom/source-tracking/pull/732 with bumped dependencies for tests.

ALL CREDIT GOES TO @lukecotter

What does this PR do?
pathIsInfolder will exit as early as possible,.
This improved overall sf project deploy start times in my project by ~19%

What issues does this PR fix or reference?
Combined with https://github.com/isomorphic-git/isomorphic-git/pull/2023 in isomorphic git I was seeing roughly 45 - 50% faster times working out the changed files to deploy.
there are also some https://github.com/isomorphic-git/isomorphic-git/pull/2063

If it is accepted it would be great to upgrade that too.
Do you want me to create an issue on the [issues repo](https://github.com/forcedotcom/cli/issues)?

[skip-validate-pr]