### PR TITLE
feat: add SF_SOURCE_TRACKING_ASSUME_SYNCED env var to skip local status scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@salesforce/core": "^8.32.2",
     "@salesforce/kit": "^3.2.6",
-    "@salesforce/source-deploy-retrieve": "^12.37.1",
+    "@salesforce/source-deploy-retrieve": "^12.36.6",
     "@salesforce/ts-types": "^2.0.12",
     "fast-xml-parser": "^5.5.7",
     "graceful-fs": "^4.2.11",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^8.31.2",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/kit": "^3.2.6",
-    "@salesforce/source-deploy-retrieve": "^12.36.6",
+    "@salesforce/source-deploy-retrieve": "^12.37.1",
     "@salesforce/ts-types": "^2.0.12",
     "fast-xml-parser": "^5.5.7",
     "graceful-fs": "^4.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/source-tracking",
   "description": "API for tracking local and remote Salesforce metadata changes",
-  "version": "7.8.19",
+  "version": "7.8.20-dev.0",
   "author": "Salesforce",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^8.32.2",
+    "@salesforce/core": "^8.31.2",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/source-deploy-retrieve": "^12.36.6",
     "@salesforce/ts-types": "^2.0.12",

--- a/src/shared/local/localShadowRepo.ts
+++ b/src/shared/local/localShadowRepo.ts
@@ -141,6 +141,17 @@ export class ShadowRepo {
   public async getStatus(noCache = false): Promise<StatusRow[]> {
     this.logger.trace(`start: getStatus (noCache = ${noCache})`);
 
+    if (env.getBoolean('SF_SOURCE_TRACKING_ASSUME_SYNCED')) {
+      if (!this.status) {
+        this.logger.warn(
+          'SF_SOURCE_TRACKING_ASSUME_SYNCED is set. Skipping local status check and assuming local files match the shadow repo.'
+        );
+        void Lifecycle.getInstance().emitTelemetry({ eventName: 'sourceTrackingAssumeSynced' });
+        this.status = [];
+      }
+      return this.status;
+    }
+
     if (!this.status || noCache) {
       try {
         // status hasn't been initialized yet

--- a/src/shared/local/localShadowRepo.ts
+++ b/src/shared/local/localShadowRepo.ts
@@ -142,7 +142,7 @@ export class ShadowRepo {
     this.logger.trace(`start: getStatus (noCache = ${noCache})`);
 
     if (env.getBoolean('SF_SOURCE_TRACKING_ASSUME_SYNCED')) {
-      if (!this.status) {
+      if (this.status?.length !== 0) {
         this.logger.warn(
           'SF_SOURCE_TRACKING_ASSUME_SYNCED is set. Skipping local status check and assuming local files match the shadow repo.'
         );

--- a/test/nuts/local/assumeSynced.nut.ts
+++ b/test/nuts/local/assumeSynced.nut.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import { TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
+import { ShadowRepo } from '../../../src/shared/local/localShadowRepo';
+
+/* eslint-disable no-unused-expressions */
+
+describe('SF_SOURCE_TRACKING_ASSUME_SYNCED (NUT)', () => {
+  let session: TestSession;
+  let repo: ShadowRepo;
+  const registry = new RegistryAccess();
+
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        sourceDir: path.join('test', 'nuts', 'ebikes-lwc'),
+      },
+      devhubAuthStrategy: 'NONE',
+    });
+  });
+
+  after(async () => {
+    delete process.env.SF_SOURCE_TRACKING_ASSUME_SYNCED;
+    await session?.clean();
+  });
+
+  it('initializes shadow repo and sees real changes without env var', async () => {
+    repo = await ShadowRepo.getInstance({
+      orgId: 'assumeSyncedNut',
+      projectPath: session.project.dir,
+      packageDirs: [{ path: 'force-app', name: 'force-app', fullPath: path.join(session.project.dir, 'force-app') }],
+      registry,
+    });
+
+    const changes = await repo.getChangedFilenames();
+    expect(changes).to.be.an('array').with.length.greaterThan(50);
+  });
+
+  it('commits all files to establish a clean baseline', async () => {
+    const sha = await repo.commitChanges({
+      deployedFiles: await repo.getChangedFilenames(),
+      message: 'baseline commit',
+    });
+    expect(sha).to.be.a('string');
+    expect(await repo.getChangedFilenames()).to.have.lengthOf(0);
+  });
+
+  it('with env var set, reports no changes even after file modifications', async () => {
+    // modify a file
+    const target = path.join(
+      session.project.dir,
+      'force-app',
+      'main',
+      'default',
+      'permissionsets',
+      'ebikes.permissionset-meta.xml'
+    );
+    const original = await fs.promises.readFile(target, 'utf8');
+    await fs.promises.writeFile(target, `${original}\n<!-- modified -->`);
+
+    // add a new file
+    await fs.promises.writeFile(
+      path.join(session.project.dir, 'force-app', 'main', 'default', 'classes', 'NewClass.cls'),
+      'public class NewClass {}'
+    );
+
+    // set the env var
+    process.env.SF_SOURCE_TRACKING_ASSUME_SYNCED = 'true';
+
+    // force a fresh status check — should still return empty
+    const status = await repo.getStatus(true);
+    expect(status).to.deep.equal([]);
+    expect(await repo.getChangedFilenames()).to.deep.equal([]);
+    expect(await repo.getDeletes()).to.deep.equal([]);
+    expect(await repo.getNonDeletes()).to.deep.equal([]);
+    expect(await repo.getAdds()).to.deep.equal([]);
+    expect(await repo.getModifies()).to.deep.equal([]);
+  });
+
+  it('commitChanges with explicit files still works when env var is set', async () => {
+    const explicitFile = path.normalize('force-app/main/default/classes/NewClass.cls');
+    const sha = await repo.commitChanges({
+      deployedFiles: [explicitFile],
+      message: 'explicit deploy with assume-synced',
+    });
+    expect(sha).to.be.a('string');
+  });
+
+  it('after unsetting env var, getStatus(true) reveals real changes', async () => {
+    delete process.env.SF_SOURCE_TRACKING_ASSUME_SYNCED;
+
+    const status = await repo.getStatus(true);
+    // the modified permissionset should show up (NewClass was already committed above)
+    expect(status.length).to.be.greaterThan(0);
+    const filenames = await repo.getChangedFilenames();
+    expect(filenames.some((f) => f.includes('ebikes.permissionset-meta.xml'))).to.be.true;
+  });
+});

--- a/test/unit/localShadowRepo.test.ts
+++ b/test/unit/localShadowRepo.test.ts
@@ -31,6 +31,44 @@ afterEach(() => {
 
 describe('localShadowRepo', () => {
   const registry = new RegistryAccess();
+
+  describe('SF_SOURCE_TRACKING_ASSUME_SYNCED', () => {
+    afterEach(() => {
+      delete process.env.SF_SOURCE_TRACKING_ASSUME_SYNCED;
+    });
+
+    it('returns empty status without calling statusMatrix when set', async () => {
+      process.env.SF_SOURCE_TRACKING_ASSUME_SYNCED = 'true';
+      let projectDir!: string;
+      try {
+        projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'localShadowRepoTest'));
+        fs.mkdirSync(path.join(projectDir, 'force-app'));
+        fs.writeFileSync(path.join(projectDir, 'force-app', 'Foo.cls'), 'public class Foo {}');
+
+        const shadowRepo: ShadowRepo = await ShadowRepo.getInstance({
+          orgId: '00D000000000001',
+          registry,
+          projectPath: projectDir,
+          packageDirs: [
+            {
+              name: 'force-app',
+              fullPath: path.join(projectDir, 'force-app'),
+              path: 'force-app',
+            },
+          ],
+        });
+
+        const statusMatrixSpy = sinon.spy(git, 'statusMatrix');
+        const status = await shadowRepo.getStatus(true);
+
+        expect(status).to.deep.equal([]);
+        expect(statusMatrixSpy.called).to.be.false;
+      } finally {
+        if (projectDir) await fs.promises.rm(projectDir, { recursive: true });
+      }
+    });
+  });
+
   it('does not add same file multiple times', async () => {
     let projectDir!: string;
     try {

--- a/test/unit/localShadowRepo.test.ts
+++ b/test/unit/localShadowRepo.test.ts
@@ -33,39 +33,88 @@ describe('localShadowRepo', () => {
   const registry = new RegistryAccess();
 
   describe('SF_SOURCE_TRACKING_ASSUME_SYNCED', () => {
-    afterEach(() => {
+    let projectDir: string;
+    let shadowRepo: ShadowRepo;
+
+    beforeEach(async () => {
+      process.env.SF_SOURCE_TRACKING_ASSUME_SYNCED = 'true';
+      projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'localShadowRepoTest'));
+      fs.mkdirSync(path.join(projectDir, 'force-app'));
+      fs.writeFileSync(path.join(projectDir, 'force-app', 'Foo.cls'), 'public class Foo {}');
+
+      shadowRepo = await ShadowRepo.getInstance({
+        orgId: '00D000000000002',
+        registry,
+        projectPath: projectDir,
+        packageDirs: [
+          {
+            name: 'force-app',
+            fullPath: path.join(projectDir, 'force-app'),
+            path: 'force-app',
+          },
+        ],
+      });
+    });
+
+    afterEach(async () => {
       delete process.env.SF_SOURCE_TRACKING_ASSUME_SYNCED;
+      if (projectDir) await fs.promises.rm(projectDir, { recursive: true });
     });
 
     it('returns empty status without calling statusMatrix when set', async () => {
-      process.env.SF_SOURCE_TRACKING_ASSUME_SYNCED = 'true';
-      let projectDir!: string;
-      try {
-        projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'localShadowRepoTest'));
-        fs.mkdirSync(path.join(projectDir, 'force-app'));
-        fs.writeFileSync(path.join(projectDir, 'force-app', 'Foo.cls'), 'public class Foo {}');
+      const statusMatrixSpy = sinon.spy(git, 'statusMatrix');
+      const status = await shadowRepo.getStatus(true);
 
-        const shadowRepo: ShadowRepo = await ShadowRepo.getInstance({
-          orgId: '00D000000000001',
-          registry,
-          projectPath: projectDir,
-          packageDirs: [
-            {
-              name: 'force-app',
-              fullPath: path.join(projectDir, 'force-app'),
-              path: 'force-app',
-            },
-          ],
-        });
+      expect(status).to.deep.equal([]);
+      expect(statusMatrixSpy.called).to.be.false;
+    });
 
-        const statusMatrixSpy = sinon.spy(git, 'statusMatrix');
-        const status = await shadowRepo.getStatus(true);
+    it('returns cached empty status on subsequent calls with noCache=true', async () => {
+      const statusMatrixSpy = sinon.spy(git, 'statusMatrix');
 
-        expect(status).to.deep.equal([]);
-        expect(statusMatrixSpy.called).to.be.false;
-      } finally {
-        if (projectDir) await fs.promises.rm(projectDir, { recursive: true });
-      }
+      const first = await shadowRepo.getStatus(true);
+      const second = await shadowRepo.getStatus(true);
+      const third = await shadowRepo.getStatus(false);
+
+      expect(first).to.deep.equal([]);
+      expect(second).to.deep.equal([]);
+      expect(third).to.deep.equal([]);
+      expect(statusMatrixSpy.called).to.be.false;
+    });
+
+    it('downstream methods return empty results', async () => {
+      expect(await shadowRepo.getChangedRows()).to.deep.equal([]);
+      expect(await shadowRepo.getChangedFilenames()).to.deep.equal([]);
+      expect(await shadowRepo.getDeletes()).to.deep.equal([]);
+      expect(await shadowRepo.getDeleteFilenames()).to.deep.equal([]);
+      expect(await shadowRepo.getNonDeletes()).to.deep.equal([]);
+      expect(await shadowRepo.getNonDeleteFilenames()).to.deep.equal([]);
+      expect(await shadowRepo.getAdds()).to.deep.equal([]);
+      expect(await shadowRepo.getAddFilenames()).to.deep.equal([]);
+      expect(await shadowRepo.getModifies()).to.deep.equal([]);
+      expect(await shadowRepo.getModifyFilenames()).to.deep.equal([]);
+    });
+
+    it('commitChanges succeeds with no files when env var is set', async () => {
+      const result = await shadowRepo.commitChanges({ deployedFiles: [], deletedFiles: [] });
+      expect(result).to.equal('no files to commit');
+    });
+
+    it('resumes real scanning after env var is unset and noCache=true', async () => {
+      // first call with env var set — returns empty
+      const emptyStatus = await shadowRepo.getStatus(true);
+      expect(emptyStatus).to.deep.equal([]);
+
+      // unset the env var
+      delete process.env.SF_SOURCE_TRACKING_ASSUME_SYNCED;
+
+      // without noCache, returns the cached empty array
+      const stillCached = await shadowRepo.getStatus(false);
+      expect(stillCached).to.deep.equal([]);
+
+      // with noCache=true, should actually scan and find the uncommitted file
+      const realStatus = await shadowRepo.getStatus(true);
+      expect(realStatus.length).to.be.greaterThan(0);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,6 +721,31 @@
     ts-retry-promise "^0.8.1"
     zod "^4.1.12"
 
+"@salesforce/core@^8.31.2":
+  version "8.32.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.32.3.tgz#e7cb6840adf59f88e7a09c8033674aa56f4a3859"
+  integrity sha512-xtF3SDLphcJPd1zNVtIIqqXHRhqUB1sI1lO8LyCiviFAlhd6ZVmPXZIsThLmOoZaRVTqy+ROnvEWBL00hN9dIg==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.10.17"
+    "@salesforce/kit" "^3.2.4"
+    "@salesforce/ts-types" "^2.0.12"
+    ajv "^8.18.0"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.1"
+    form-data "^4.0.5"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.3"
+    jszip "3.10.1"
+    memfs "4.38.1"
+    pino "^9.7.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.3.0"
+    proper-lockfile "^4.1.2"
+    semver "^7.8.0"
+    ts-retry-promise "^0.8.1"
+    zod "^4.1.12"
+
 "@salesforce/core@^8.32.2":
   version "8.32.2"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.32.2.tgz#faa4d7525cebb7c46e6b576d6fb4c0624592d779"

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,7 +721,7 @@
     ts-retry-promise "^0.8.1"
     zod "^4.1.12"
 
-"@salesforce/core@^8.31.5", "@salesforce/core@^8.32.2":
+"@salesforce/core@^8.32.2":
   version "8.32.2"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.32.2.tgz#faa4d7525cebb7c46e6b576d6fb4c0624592d779"
   integrity sha512-IenGtnr68o1Pg8WDA5XUDeuqTmdCbAyLCAU1hdbIcqM3kyEfvyaHgou0/KfEx6EokCxJ4MZFJ6MmjL8dY53XGQ==
@@ -807,12 +807,12 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.10.3.tgz#52c867fdd60679cf216110aa49542b7ad391f5d1"
   integrity sha512-FKfvtrYTcvTXE9advzS25/DEY9yJhEyLvStm++eQFtnAaX1pe4G3oGHgiQ0q55BM5+0AlCh0+0CVtQv1t4oJRA==
 
-"@salesforce/source-deploy-retrieve@^12.37.1":
-  version "12.37.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.37.1.tgz#b028db0b2c64afe7485877d12f96c7df3582ea3e"
-  integrity sha512-K2M54QGIvYq0r1KnlM0PAw/Aoez1c/YRASbFWutLkmvJ1SqWxglH0nB6Yu7H+a+wogdLGW3I5JVhxT1CWXgUqA==
+"@salesforce/source-deploy-retrieve@^12.36.6":
+  version "12.37.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.37.2.tgz#442f3be88d91021de14af6371d9f954689157ce7"
+  integrity sha512-wgG0RccjQ8CaBEO8woSvvTyxc6V7KIw1GbZlME0bU+Ly+2G8pdPHAm43hrBTBml5MdYVh3J3yZwMyIeRaQxeBA==
   dependencies:
-    "@salesforce/core" "^8.31.5"
+    "@salesforce/core" "^8.32.2"
     "@salesforce/kit" "^3.2.4"
     "@salesforce/ts-types" "^2.0.12"
     "@salesforce/types" "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,6 +586,21 @@
     node-fetch "^2.6.1"
     xml2js "^0.6.2"
 
+"@jsforce/jsforce-node@^3.10.17":
+  version "3.10.19"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.19.tgz#ccbc539c12f4f7dff9cfdcc6cfb8f07bd840f731"
+  integrity sha512-k7i2Tntu1fLvkMtRcKDFU64/Fr2M692ECtbwIGX6hcOh5mj+jrMa1tlvcdwffxAMl+lPYCXnY2bjErxWmP84zA==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.6.0"
+    faye "^1.4.0"
+    form-data "^4.0.4"
+    multistream "^3.1.0"
+    undici "^8.5.0"
+    xml2js "^0.6.2"
+
 "@jsonjoy.com/base64@^1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz"
@@ -706,12 +721,12 @@
     ts-retry-promise "^0.8.1"
     zod "^4.1.12"
 
-"@salesforce/core@^8.31.2":
-  version "8.31.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.2.tgz#968448f423b553f726f42c27da6b55c4ec7eb93a"
-  integrity sha512-naqnq7Z+gbl1LdnyNvrGrNUoeMUQtCOsnrS6DfqeuLMJTFqcL9Dq0/od+xcuqi0+l7HTyH0/gU1BQitWpd1rag==
+"@salesforce/core@^8.31.5", "@salesforce/core@^8.32.2":
+  version "8.32.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.32.2.tgz#faa4d7525cebb7c46e6b576d6fb4c0624592d779"
+  integrity sha512-IenGtnr68o1Pg8WDA5XUDeuqTmdCbAyLCAU1hdbIcqM3kyEfvyaHgou0/KfEx6EokCxJ4MZFJ6MmjL8dY53XGQ==
   dependencies:
-    "@jsforce/jsforce-node" "^3.10.13"
+    "@jsforce/jsforce-node" "^3.10.17"
     "@salesforce/kit" "^3.2.4"
     "@salesforce/ts-types" "^2.0.12"
     ajv "^8.18.0"
@@ -792,12 +807,12 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.10.3.tgz#52c867fdd60679cf216110aa49542b7ad391f5d1"
   integrity sha512-FKfvtrYTcvTXE9advzS25/DEY9yJhEyLvStm++eQFtnAaX1pe4G3oGHgiQ0q55BM5+0AlCh0+0CVtQv1t4oJRA==
 
-"@salesforce/source-deploy-retrieve@^12.36.6":
-  version "12.36.6"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.36.6.tgz#4c1e701cff9c9fa2802e8fa7e3ba2188426d47d1"
-  integrity sha512-1tz3eUyHp0yIAylrz+njlxGejd08cwPys9LjfBTVeY6a+xOBkTTDgQMLA6OBBZVc0HMPqjkJMKvbtDrAD5MJBA==
+"@salesforce/source-deploy-retrieve@^12.37.1":
+  version "12.37.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.37.1.tgz#b028db0b2c64afe7485877d12f96c7df3582ea3e"
+  integrity sha512-K2M54QGIvYq0r1KnlM0PAw/Aoez1c/YRASbFWutLkmvJ1SqWxglH0nB6Yu7H+a+wogdLGW3I5JVhxT1CWXgUqA==
   dependencies:
-    "@salesforce/core" "^8.31.2"
+    "@salesforce/core" "^8.31.5"
     "@salesforce/kit" "^3.2.4"
     "@salesforce/ts-types" "^2.0.12"
     "@salesforce/types" "^1.6.0"
@@ -2926,17 +2941,6 @@ foreground-child@^3.1.0, foreground-child@^3.3.0:
     signal-exit "^4.0.1"
 
 form-data@^4.0.4, form-data@^4.0.5:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
-  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    hasown "^2.0.4"
-    mime-types "^2.1.35"
-
-form-data@^4.0.5:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
   integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
@@ -6281,6 +6285,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici@^8.5.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-8.7.0.tgz#04c5aae1db34d9867488588b44b8c749dee9baee"
+  integrity sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==
 
 unist-util-is@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## Summary

- Adds `SF_SOURCE_TRACKING_ASSUME_SYNCED` environment variable that bypasses the expensive `git.statusMatrix()` call in `ShadowRepo.getStatus()`
- When set, local source tracking assumes files already match the shadow repo (returns empty status), eliminating the 13–60 minute resync penalty caused by timestamp drift after org transplant (e.g., OrgFarm → developer machine)
- Remote tracking (SourceMember reconciliation) is unaffected and still runs normally

## Context

nCino's OrgFarm workflow pre-deploys source into pooled scratch orgs and seeds the shadow repo. When developers harvest an org, all file timestamps change, causing `isomorphic-git` to re-hash every file on the next tracking operation. For nForce (~70K files) this takes 13+ minutes; for LLC_BI (~250K files) it can exceed 30 minutes.

This env var lets nCino (and similar workflows) assert "I know local and shadow are in sync" and skip the full filesystem scan. The flag emits a warning log and telemetry event on first use for observability.

@W-23389121@

## Test plan

- [x] Unit test verifies `getStatus()` returns `[]` without calling `statusMatrix` when env var is set
- [x] All 37 existing unit tests pass
- [x] Validated against DreamhouseLWC test project: tracking reset drops from 102ms to 1ms
- [ ] nCino validates with LLC_BI-scale project (250K+ files)